### PR TITLE
Update dependencies, make kysely a peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,24 @@
 			"license": "MIT",
 			"dependencies": {
 				"@sqlite.org/sqlite-wasm": "^3.44.2-build1",
-				"kysely": "^0.26.3",
-				"nanoid": "^4.0.2"
+				"nanoid": "~5"
 			},
 			"devDependencies": {
 				"@vitest/browser": "^1.2.1",
-				"drizzle-orm": "^0.29.1",
-				"prettier": "^2.8.8",
+				"drizzle-orm": "^0.29.3",
+				"prettier": "3.2.4",
 				"typescript": "^5.3.3",
 				"vite": "^5.0.12",
-				"vitepress": "^1.0.0-beta.5",
+				"vitepress": "^1.0.0-rc.39",
 				"vitest": "^1.2.1",
 				"webdriverio": "^8.28.8"
+			},
+			"funding": {
+				"type": "paypal",
+				"url": "https://www.paypal.com/biz/fund?id=U3ZNM2Q26WJY8"
+			},
+			"peerDependencies": {
+				"kysely": "*"
 			}
 		},
 		"node_modules/@algolia/autocomplete-core": {
@@ -70,138 +76,138 @@
 			}
 		},
 		"node_modules/@algolia/cache-browser-local-storage": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.18.0.tgz",
-			"integrity": "sha512-rUAs49NLlO8LVLgGzM4cLkw8NJLKguQLgvFmBEe3DyzlinoqxzQMHfKZs6TSq4LZfw/z8qHvRo8NcTAAUJQLcw==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.1.tgz",
+			"integrity": "sha512-Sw6IAmOCvvP6QNgY9j+Hv09mvkvEIDKjYW8ow0UDDAxSXy664RBNQk3i/0nt7gvceOJ6jGmOTimaZoY1THmU7g==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/cache-common": "4.18.0"
+				"@algolia/cache-common": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/cache-common": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.18.0.tgz",
-			"integrity": "sha512-BmxsicMR4doGbeEXQu8yqiGmiyvpNvejYJtQ7rvzttEAMxOPoWEHrWyzBQw4x7LrBY9pMrgv4ZlUaF8PGzewHg==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.1.tgz",
+			"integrity": "sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA==",
 			"dev": true
 		},
 		"node_modules/@algolia/cache-in-memory": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.18.0.tgz",
-			"integrity": "sha512-evD4dA1nd5HbFdufBxLqlJoob7E2ozlqJZuV3YlirNx5Na4q1LckIuzjNYZs2ddLzuTc/Xd5O3Ibf7OwPskHxw==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.1.tgz",
+			"integrity": "sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/cache-common": "4.18.0"
+				"@algolia/cache-common": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/client-account": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.18.0.tgz",
-			"integrity": "sha512-XsDnlROr3+Z1yjxBJjUMfMazi1V155kVdte6496atvBgOEtwCzTs3A+qdhfsAnGUvaYfBrBkL0ThnhMIBCGcew==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.1.tgz",
+			"integrity": "sha512-k8m+oegM2zlns/TwZyi4YgCtyToackkOpE+xCaKCYfBfDtdGOaVZCM5YvGPtK+HGaJMIN/DoTL8asbM3NzHonw==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/client-common": "4.18.0",
-				"@algolia/client-search": "4.18.0",
-				"@algolia/transporter": "4.18.0"
+				"@algolia/client-common": "4.22.1",
+				"@algolia/client-search": "4.22.1",
+				"@algolia/transporter": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/client-analytics": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.18.0.tgz",
-			"integrity": "sha512-chEUSN4ReqU7uRQ1C8kDm0EiPE+eJeAXiWcBwLhEynfNuTfawN9P93rSZktj7gmExz0C8XmkbBU19IQ05wCNrQ==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.1.tgz",
+			"integrity": "sha512-1ssi9pyxyQNN4a7Ji9R50nSdISIumMFDwKNuwZipB6TkauJ8J7ha/uO60sPJFqQyqvvI+px7RSNRQT3Zrvzieg==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/client-common": "4.18.0",
-				"@algolia/client-search": "4.18.0",
-				"@algolia/requester-common": "4.18.0",
-				"@algolia/transporter": "4.18.0"
+				"@algolia/client-common": "4.22.1",
+				"@algolia/client-search": "4.22.1",
+				"@algolia/requester-common": "4.22.1",
+				"@algolia/transporter": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/client-common": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.18.0.tgz",
-			"integrity": "sha512-7N+soJFP4wn8tjTr3MSUT/U+4xVXbz4jmeRfWfVAzdAbxLAQbHa0o/POSdTvQ8/02DjCLelloZ1bb4ZFVKg7Wg==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.1.tgz",
+			"integrity": "sha512-IvaL5v9mZtm4k4QHbBGDmU3wa/mKokmqNBqPj0K7lcR8ZDKzUorhcGp/u8PkPC/e0zoHSTvRh7TRkGX3Lm7iOQ==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/requester-common": "4.18.0",
-				"@algolia/transporter": "4.18.0"
+				"@algolia/requester-common": "4.22.1",
+				"@algolia/transporter": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/client-personalization": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.18.0.tgz",
-			"integrity": "sha512-+PeCjODbxtamHcPl+couXMeHEefpUpr7IHftj4Y4Nia1hj8gGq4VlIcqhToAw8YjLeCTfOR7r7xtj3pJcYdP8A==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.1.tgz",
+			"integrity": "sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/client-common": "4.18.0",
-				"@algolia/requester-common": "4.18.0",
-				"@algolia/transporter": "4.18.0"
+				"@algolia/client-common": "4.22.1",
+				"@algolia/requester-common": "4.22.1",
+				"@algolia/transporter": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/client-search": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.18.0.tgz",
-			"integrity": "sha512-F9xzQXTjm6UuZtnsLIew6KSraXQ0AzS/Ee+OD+mQbtcA/K1sg89tqb8TkwjtiYZ0oij13u3EapB3gPZwm+1Y6g==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.1.tgz",
+			"integrity": "sha512-yb05NA4tNaOgx3+rOxAmFztgMTtGBi97X7PC3jyNeGiwkAjOZc2QrdZBYyIdcDLoI09N0gjtpClcackoTN0gPA==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/client-common": "4.18.0",
-				"@algolia/requester-common": "4.18.0",
-				"@algolia/transporter": "4.18.0"
+				"@algolia/client-common": "4.22.1",
+				"@algolia/requester-common": "4.22.1",
+				"@algolia/transporter": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/logger-common": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.18.0.tgz",
-			"integrity": "sha512-46etYgSlkoKepkMSyaoriSn2JDgcrpc/nkOgou/lm0y17GuMl9oYZxwKKTSviLKI5Irk9nSKGwnBTQYwXOYdRg==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.1.tgz",
+			"integrity": "sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg==",
 			"dev": true
 		},
 		"node_modules/@algolia/logger-console": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.18.0.tgz",
-			"integrity": "sha512-3P3VUYMl9CyJbi/UU1uUNlf6Z8N2ltW3Oqhq/nR7vH0CjWv32YROq3iGWGxB2xt3aXobdUPXs6P0tHSKRmNA6g==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.1.tgz",
+			"integrity": "sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/logger-common": "4.18.0"
+				"@algolia/logger-common": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.18.0.tgz",
-			"integrity": "sha512-/AcWHOBub2U4TE/bPi4Gz1XfuLK6/7dj4HJG+Z2SfQoS1RjNLshZclU3OoKIkFp8D2NC7+BNsPvr9cPLyW8nyQ==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.1.tgz",
+			"integrity": "sha512-dtQGYIg6MteqT1Uay3J/0NDqD+UciHy3QgRbk7bNddOJu+p3hzjTRYESqEnoX/DpEkaNYdRHUKNylsqMpgwaEw==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/requester-common": "4.18.0"
+				"@algolia/requester-common": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/requester-common": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.18.0.tgz",
-			"integrity": "sha512-xlT8R1qYNRBCi1IYLsx7uhftzdfsLPDGudeQs+xvYB4sQ3ya7+ppolB/8m/a4F2gCkEO6oxpp5AGemM7kD27jA==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.1.tgz",
+			"integrity": "sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg==",
 			"dev": true
 		},
 		"node_modules/@algolia/requester-node-http": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.18.0.tgz",
-			"integrity": "sha512-TGfwj9aeTVgOUhn5XrqBhwUhUUDnGIKlI0kCBMdR58XfXcfdwomka+CPIgThRbfYw04oQr31A6/95ZH2QVJ9UQ==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.1.tgz",
+			"integrity": "sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/requester-common": "4.18.0"
+				"@algolia/requester-common": "4.22.1"
 			}
 		},
 		"node_modules/@algolia/transporter": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.18.0.tgz",
-			"integrity": "sha512-xbw3YRUGtXQNG1geYFEDDuFLZt4Z8YNKbamHPkzr3rWc6qp4/BqEeXcI2u/P/oMq2yxtXgMxrCxOPA8lyIe5jw==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.1.tgz",
+			"integrity": "sha512-kzWgc2c9IdxMa3YqA6TN0NW5VrKYYW/BELIn7vnLyn+U/RFdZ4lxxt9/8yq3DKV5snvoDzzO4ClyejZRdV3lMQ==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/cache-common": "4.18.0",
-				"@algolia/logger-common": "4.18.0",
-				"@algolia/requester-common": "4.18.0"
+				"@algolia/cache-common": "4.22.1",
+				"@algolia/logger-common": "4.22.1",
+				"@algolia/requester-common": "4.22.1"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-			"integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -211,36 +217,37 @@
 			}
 		},
 		"node_modules/@docsearch/css": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.1.tgz",
-			"integrity": "sha512-2Pu9HDg/uP/IT10rbQ+4OrTQuxIWdKVUEdcw9/w7kZJv9NeHS6skJx1xuRiFyoGKwAzcHXnLp7csE99sj+O1YA==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+			"integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
 			"dev": true
 		},
 		"node_modules/@docsearch/js": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.1.tgz",
-			"integrity": "sha512-EXi8de5njxgP6TV3N9ytnGRLG9zmBNTEZjR4VzwPcpPLbZxxTLG2gaFyJyKiFVQxHW/DPlMrDJA3qoRRGEkgZw==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.2.tgz",
+			"integrity": "sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==",
 			"dev": true,
 			"dependencies": {
-				"@docsearch/react": "3.5.1",
+				"@docsearch/react": "3.5.2",
 				"preact": "^10.0.0"
 			}
 		},
 		"node_modules/@docsearch/react": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.1.tgz",
-			"integrity": "sha512-t5mEODdLzZq4PTFAm/dvqcvZFdPDMdfPE5rJS5SC8OUq9mPzxEy6b+9THIqNM9P0ocCb4UC5jqBrxKclnuIbzQ==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+			"integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
 			"dev": true,
 			"dependencies": {
 				"@algolia/autocomplete-core": "1.9.3",
 				"@algolia/autocomplete-preset-algolia": "1.9.3",
-				"@docsearch/css": "3.5.1",
-				"algoliasearch": "^4.0.0"
+				"@docsearch/css": "3.5.2",
+				"algoliasearch": "^4.19.1"
 			},
 			"peerDependencies": {
 				"@types/react": ">= 16.8.0 < 19.0.0",
 				"react": ">= 16.8.0 < 19.0.0",
-				"react-dom": ">= 16.8.0 < 19.0.0"
+				"react-dom": ">= 16.8.0 < 19.0.0",
+				"search-insights": ">= 1 < 3"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -251,55 +258,10 @@
 				},
 				"react-dom": {
 					"optional": true
+				},
+				"search-insights": {
+					"optional": true
 				}
-			}
-		},
-		"node_modules/@esbuild/android-arm": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
-			"integrity": "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/android-arm64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz",
-			"integrity": "sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/android-x64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.8.tgz",
-			"integrity": "sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
@@ -313,294 +275,6 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz",
-			"integrity": "sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz",
-			"integrity": "sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz",
-			"integrity": "sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-arm": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz",
-			"integrity": "sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz",
-			"integrity": "sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz",
-			"integrity": "sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz",
-			"integrity": "sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz",
-			"integrity": "sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz",
-			"integrity": "sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz",
-			"integrity": "sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz",
-			"integrity": "sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/linux-x64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz",
-			"integrity": "sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz",
-			"integrity": "sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz",
-			"integrity": "sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz",
-			"integrity": "sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz",
-			"integrity": "sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz",
-			"integrity": "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@esbuild/win32-x64": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz",
-			"integrity": "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=12"
@@ -678,32 +352,6 @@
 				"node": ">=16.3.0"
 			}
 		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.7.0.tgz",
-			"integrity": "sha512-rGku10pL1StFlFvXX5pEv88KdGW6DHUghsxyP/aRYb9eH+74jTGJ3U0S/rtlsQ4yYq1Hcc7AMkoJOb1xu29Fxw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.7.0.tgz",
-			"integrity": "sha512-/EBw0cuJ/KVHiU2qyVYUhogXz7W2vXxBzeE9xtVIMC+RyitlY2vvaoysMUqASpkUtoNIHlnKTu/l7mXOPgnKOA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.7.0.tgz",
@@ -715,136 +363,6 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.7.0.tgz",
-			"integrity": "sha512-/ImhO+T/RWJ96hUbxiCn2yWI0/MeQZV/aeukQQfhxiSXuZJfyqtdHPUPrc84jxCfXTxbJLmg4q+GBETeb61aNw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.7.0.tgz",
-			"integrity": "sha512-zhye8POvTyUXlKbfPBVqoHy3t43gIgffY+7qBFqFxNqVtltQLtWeHNAbrMnXiLIfYmxcoL/feuLDote2tx+Qbg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.7.0.tgz",
-			"integrity": "sha512-RAdr3OJnUum6Vs83cQmKjxdTg31zJnLLTkjhcFt0auxM6jw00GD6IPFF42uasYPr/wGC6TRm7FsQiJyk0qIEfg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.7.0.tgz",
-			"integrity": "sha512-nhWwYsiJwZGq7SyR3afS3EekEOsEAlrNMpPC4ZDKn5ooYSEjDLe9W/xGvoIV8/F/+HNIY6jY8lIdXjjxfxopXw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.7.0.tgz",
-			"integrity": "sha512-rlfy5RnQG1aop1BL/gjdH42M2geMUyVQqd52GJVirqYc787A/XVvl3kQ5NG/43KXgOgE9HXgCaEH05kzQ+hLoA==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.7.0.tgz",
-			"integrity": "sha512-cCkoGlGWfBobdDtiiypxf79q6k3/iRVGu1HVLbD92gWV5WZbmuWJCgRM4x2N6i7ljGn1cGytPn9ZAfS8UwF6vg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.7.0.tgz",
-			"integrity": "sha512-R2oBf2p/Arc1m+tWmiWbpHBjEcJnHVnv6bsypu4tcKdrYTpDfl1UT9qTyfkIL1iiii5D4WHxUHCg5X0pzqmxFg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.7.0.tgz",
-			"integrity": "sha512-CPtgaQL1aaPc80m8SCVEoxFGHxKYIt3zQYC3AccL/SqqiWXblo3pgToHuBwR8eCP2Toa+X1WmTR/QKFMykws7g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.7.0.tgz",
-			"integrity": "sha512-pmioUlttNh9GXF5x2CzNa7Z8kmRTyhEzzAC+2WOOapjewMbl+3tGuAnxbwc5JyG8Jsz2+hf/QD/n5VjimOZ63g==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.7.0.tgz",
-			"integrity": "sha512-SeZzC2QhhdBQUm3U0c8+c/P6UlRyBcLL2Xp5KX7z46WXZxzR8RJSIWL9wSUeBTgxog5LTPJuPj0WOT9lvrtP7Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
 			]
 		},
 		"node_modules/@sinclair/typebox": {
@@ -903,6 +421,28 @@
 			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
 			"dev": true
 		},
+		"node_modules/@types/linkify-it": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+			"integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+			"dev": true
+		},
+		"node_modules/@types/markdown-it": {
+			"version": "13.0.7",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
+			"integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
+			"dev": true,
+			"dependencies": {
+				"@types/linkify-it": "*",
+				"@types/mdurl": "*"
+			}
+		},
+		"node_modules/@types/mdurl": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+			"integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+			"dev": true
+		},
 		"node_modules/@types/node": {
 			"version": "20.3.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
@@ -910,9 +450,9 @@
 			"dev": true
 		},
 		"node_modules/@types/web-bluetooth": {
-			"version": "0.0.17",
-			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
-			"integrity": "sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==",
+			"version": "0.0.20",
+			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+			"integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
 			"dev": true
 		},
 		"node_modules/@types/which": {
@@ -941,15 +481,15 @@
 			}
 		},
 		"node_modules/@vitejs/plugin-vue": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.2.tgz",
-			"integrity": "sha512-UGR3DlzLi/SaVBPX0cnSyE37vqxU3O6chn8l0HJNzQzDia6/Au2A4xKv+iIJW8w2daf80G7TYHhi1pAUjdZ0bQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
+			"integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
 			"dev": true,
 			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"peerDependencies": {
-				"vite": "^4.0.0 || ^5.0.0",
+				"vite": "^5.0.0",
 				"vue": "^3.2.25"
 			}
 		},
@@ -1053,13 +593,14 @@
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-			"integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.15.tgz",
+			"integrity": "sha512-XcJQVOaxTKCnth1vCxEChteGuwG6wqnUHxAm1DO3gCz0+uXKaJNx8/digSz4dLALCy8n2lKq24jSUs8segoqIw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/parser": "^7.21.3",
-				"@vue/shared": "3.3.4",
+				"@babel/parser": "^7.23.6",
+				"@vue/shared": "3.4.15",
+				"entities": "^4.5.0",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.0.2"
 			}
@@ -1071,30 +612,29 @@
 			"dev": true
 		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-			"integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.15.tgz",
+			"integrity": "sha512-wox0aasVV74zoXyblarOM3AZQz/Z+OunYcIHe1OsGclCHt8RsRm04DObjefaI82u6XDzv+qGWZ24tIsRAIi5MQ==",
 			"dev": true,
 			"dependencies": {
-				"@vue/compiler-core": "3.3.4",
-				"@vue/shared": "3.3.4"
+				"@vue/compiler-core": "3.4.15",
+				"@vue/shared": "3.4.15"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-			"integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.15.tgz",
+			"integrity": "sha512-LCn5M6QpkpFsh3GQvs2mJUOAlBQcCco8D60Bcqmf3O3w5a+KWS5GvYbrrJBkgvL1BDnTp+e8q0lXCLgHhKguBA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/parser": "^7.20.15",
-				"@vue/compiler-core": "3.3.4",
-				"@vue/compiler-dom": "3.3.4",
-				"@vue/compiler-ssr": "3.3.4",
-				"@vue/reactivity-transform": "3.3.4",
-				"@vue/shared": "3.3.4",
+				"@babel/parser": "^7.23.6",
+				"@vue/compiler-core": "3.4.15",
+				"@vue/compiler-dom": "3.4.15",
+				"@vue/compiler-ssr": "3.4.15",
+				"@vue/shared": "3.4.15",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.0",
-				"postcss": "^8.1.10",
+				"magic-string": "^0.30.5",
+				"postcss": "^8.4.33",
 				"source-map-js": "^1.0.2"
 			}
 		},
@@ -1105,108 +645,89 @@
 			"dev": true
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-			"integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.15.tgz",
+			"integrity": "sha512-1jdeQyiGznr8gjFDadVmOJqZiLNSsMa5ZgqavkPZ8O2wjHv0tVuAEsw5hTdUoUW4232vpBbL/wJhzVW/JwY1Uw==",
 			"dev": true,
 			"dependencies": {
-				"@vue/compiler-dom": "3.3.4",
-				"@vue/shared": "3.3.4"
+				"@vue/compiler-dom": "3.4.15",
+				"@vue/shared": "3.4.15"
 			}
 		},
 		"node_modules/@vue/devtools-api": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-			"integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
+			"integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==",
 			"dev": true
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-			"integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.15.tgz",
+			"integrity": "sha512-55yJh2bsff20K5O84MxSvXKPHHt17I2EomHznvFiJCAZpJTNW8IuLj1xZWMLELRhBK3kkFV/1ErZGHJfah7i7w==",
 			"dev": true,
 			"dependencies": {
-				"@vue/shared": "3.3.4"
+				"@vue/shared": "3.4.15"
 			}
-		},
-		"node_modules/@vue/reactivity-transform": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-			"integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/parser": "^7.20.15",
-				"@vue/compiler-core": "3.3.4",
-				"@vue/shared": "3.3.4",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.0"
-			}
-		},
-		"node_modules/@vue/reactivity-transform/node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"dev": true
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-			"integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.15.tgz",
+			"integrity": "sha512-6E3by5m6v1AkW0McCeAyhHTw+3y17YCOKG0U0HDKDscV4Hs0kgNT5G+GCHak16jKgcCDHpI9xe5NKb8sdLCLdw==",
 			"dev": true,
 			"dependencies": {
-				"@vue/reactivity": "3.3.4",
-				"@vue/shared": "3.3.4"
+				"@vue/reactivity": "3.4.15",
+				"@vue/shared": "3.4.15"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-			"integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.15.tgz",
+			"integrity": "sha512-EVW8D6vfFVq3V/yDKNPBFkZKGMFSvZrUQmx196o/v2tHKdwWdiZjYUBS+0Ez3+ohRyF8Njwy/6FH5gYJ75liUw==",
 			"dev": true,
 			"dependencies": {
-				"@vue/runtime-core": "3.3.4",
-				"@vue/shared": "3.3.4",
-				"csstype": "^3.1.1"
+				"@vue/runtime-core": "3.4.15",
+				"@vue/shared": "3.4.15",
+				"csstype": "^3.1.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-			"integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.15.tgz",
+			"integrity": "sha512-3HYzaidu9cHjrT+qGUuDhFYvF/j643bHC6uUN9BgM11DVy+pM6ATsG6uPBLnkwOgs7BpJABReLmpL3ZPAsUaqw==",
 			"dev": true,
 			"dependencies": {
-				"@vue/compiler-ssr": "3.3.4",
-				"@vue/shared": "3.3.4"
+				"@vue/compiler-ssr": "3.4.15",
+				"@vue/shared": "3.4.15"
 			},
 			"peerDependencies": {
-				"vue": "3.3.4"
+				"vue": "3.4.15"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-			"integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.15.tgz",
+			"integrity": "sha512-KzfPTxVaWfB+eGcGdbSf4CWdaXcGDqckoeXUh7SB3fZdEtzPCK2Vq9B/lRRL3yutax/LWITz+SwvgyOxz5V75g==",
 			"dev": true
 		},
 		"node_modules/@vueuse/core": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.2.1.tgz",
-			"integrity": "sha512-c441bfMbkAwTNwVRHQ0zdYZNETK//P84rC01aP2Uy/aRFCiie9NE/k9KdIXbno0eDYP5NPUuWv0aA/I4Unr/7w==",
+			"version": "10.7.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.2.tgz",
+			"integrity": "sha512-AOyAL2rK0By62Hm+iqQn6Rbu8bfmbgaIMXcE3TSr7BdQ42wnSFlwIdPjInO62onYsEMK/yDMU8C6oGfDAtZ2qQ==",
 			"dev": true,
 			"dependencies": {
-				"@types/web-bluetooth": "^0.0.17",
-				"@vueuse/metadata": "10.2.1",
-				"@vueuse/shared": "10.2.1",
-				"vue-demi": ">=0.14.5"
+				"@types/web-bluetooth": "^0.0.20",
+				"@vueuse/metadata": "10.7.2",
+				"@vueuse/shared": "10.7.2",
+				"vue-demi": ">=0.14.6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/core/node_modules/vue-demi": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
-			"integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
+			"version": "0.14.6",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+			"integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1230,14 +751,14 @@
 			}
 		},
 		"node_modules/@vueuse/integrations": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.2.1.tgz",
-			"integrity": "sha512-FDP5lni+z9FjHE9H3xuvwSjoRV9U8jmDvJpmHPCBjUgPGYRynwb60eHWXCFJXLUtb4gSIHy0e+iaEbrKdalCkQ==",
+			"version": "10.7.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.7.2.tgz",
+			"integrity": "sha512-+u3RLPFedjASs5EKPc69Ge49WNgqeMfSxFn+qrQTzblPXZg6+EFzhjarS5edj2qAf6xQ93f95TUxRwKStXj/sQ==",
 			"dev": true,
 			"dependencies": {
-				"@vueuse/core": "10.2.1",
-				"@vueuse/shared": "10.2.1",
-				"vue-demi": ">=0.14.5"
+				"@vueuse/core": "10.7.2",
+				"@vueuse/shared": "10.7.2",
+				"vue-demi": ">=0.14.6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -1296,9 +817,9 @@
 			}
 		},
 		"node_modules/@vueuse/integrations/node_modules/vue-demi": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
-			"integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
+			"version": "0.14.6",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+			"integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1322,30 +843,30 @@
 			}
 		},
 		"node_modules/@vueuse/metadata": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.2.1.tgz",
-			"integrity": "sha512-3Gt68mY/i6bQvFqx7cuGBzrCCQu17OBaGWS5JdwISpMsHnMKKjC2FeB5OAfMcCQ0oINfADP3i9A4PPRo0peHdQ==",
+			"version": "10.7.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.2.tgz",
+			"integrity": "sha512-kCWPb4J2KGrwLtn1eJwaJD742u1k5h6v/St5wFe8Quih90+k2a0JP8BS4Zp34XUuJqS2AxFYMb1wjUL8HfhWsQ==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/shared": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.2.1.tgz",
-			"integrity": "sha512-QWHq2bSuGptkcxx4f4M/fBYC3Y8d3M2UYyLsyzoPgEoVzJURQ0oJeWXu79OiLlBb8gTKkqe4mO85T/sf39mmiw==",
+			"version": "10.7.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.2.tgz",
+			"integrity": "sha512-qFbXoxS44pi2FkgFjPvF4h7c9oMDutpyBdcJdMYIMg9XyXli2meFMuaKn+UMgsClo//Th6+beeCgqweT/79BVA==",
 			"dev": true,
 			"dependencies": {
-				"vue-demi": ">=0.14.5"
+				"vue-demi": ">=0.14.6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/shared/node_modules/vue-demi": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
-			"integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
+			"version": "0.14.6",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+			"integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1489,25 +1010,25 @@
 			}
 		},
 		"node_modules/algoliasearch": {
-			"version": "4.18.0",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.18.0.tgz",
-			"integrity": "sha512-pCuVxC1SVcpc08ENH32T4sLKSyzoU7TkRIDBMwSLfIiW+fq4znOmWDkAygHZ6pRcO9I1UJdqlfgnV7TRj+MXrA==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.1.tgz",
+			"integrity": "sha512-jwydKFQJKIx9kIZ8Jm44SdpigFwRGPESaxZBaHSV0XWN2yBJAOT4mT7ppvlrpA4UGzz92pqFnVKr/kaZXrcreg==",
 			"dev": true,
 			"dependencies": {
-				"@algolia/cache-browser-local-storage": "4.18.0",
-				"@algolia/cache-common": "4.18.0",
-				"@algolia/cache-in-memory": "4.18.0",
-				"@algolia/client-account": "4.18.0",
-				"@algolia/client-analytics": "4.18.0",
-				"@algolia/client-common": "4.18.0",
-				"@algolia/client-personalization": "4.18.0",
-				"@algolia/client-search": "4.18.0",
-				"@algolia/logger-common": "4.18.0",
-				"@algolia/logger-console": "4.18.0",
-				"@algolia/requester-browser-xhr": "4.18.0",
-				"@algolia/requester-common": "4.18.0",
-				"@algolia/requester-node-http": "4.18.0",
-				"@algolia/transporter": "4.18.0"
+				"@algolia/cache-browser-local-storage": "4.22.1",
+				"@algolia/cache-common": "4.22.1",
+				"@algolia/cache-in-memory": "4.22.1",
+				"@algolia/client-account": "4.22.1",
+				"@algolia/client-analytics": "4.22.1",
+				"@algolia/client-common": "4.22.1",
+				"@algolia/client-personalization": "4.22.1",
+				"@algolia/client-search": "4.22.1",
+				"@algolia/logger-common": "4.22.1",
+				"@algolia/logger-console": "4.22.1",
+				"@algolia/requester-browser-xhr": "4.22.1",
+				"@algolia/requester-common": "4.22.1",
+				"@algolia/requester-node-http": "4.22.1",
+				"@algolia/transporter": "4.22.1"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -1521,12 +1042,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
-		},
-		"node_modules/ansi-sequence-parser": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
-			"integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
-			"dev": true
 		},
 		"node_modules/ansi-styles": {
 			"version": "5.2.0",
@@ -1709,12 +1224,6 @@
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
 			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-			"dev": true
-		},
-		"node_modules/body-scroll-lock": {
-			"version": "4.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz",
-			"integrity": "sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==",
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
@@ -2134,9 +1643,9 @@
 			"dev": true
 		},
 		"node_modules/csstype": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
 			"dev": true
 		},
 		"node_modules/data-uri-to-buffer": {
@@ -2273,9 +1782,9 @@
 			}
 		},
 		"node_modules/drizzle-orm": {
-			"version": "0.29.1",
-			"resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.29.1.tgz",
-			"integrity": "sha512-yItc4unfHnk8XkDD3/bdC63vdboTY7e7I03lCF1OJYABXSIfQYU9BFTQJXMMovVeb3T1/OJWwfW/70T1XPnuUA==",
+			"version": "0.29.3",
+			"resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.29.3.tgz",
+			"integrity": "sha512-uSE027csliGSGYD0pqtM+SAQATMREb3eSM/U8s6r+Y0RFwTKwftnwwSkqx3oS65UBgqDOM0gMTl5UGNpt6lW0A==",
 			"dev": true,
 			"peerDependencies": {
 				"@aws-sdk/client-rds-data": ">=3",
@@ -2286,15 +1795,18 @@
 				"@planetscale/database": ">=1",
 				"@types/better-sqlite3": "*",
 				"@types/pg": "*",
+				"@types/react": ">=18",
 				"@types/sql.js": "*",
 				"@vercel/postgres": "*",
 				"better-sqlite3": ">=7",
 				"bun-types": "*",
+				"expo-sqlite": ">=13.2.0",
 				"knex": "*",
 				"kysely": "*",
 				"mysql2": ">=2",
 				"pg": ">=8",
 				"postgres": ">=3",
+				"react": ">=18",
 				"sql.js": ">=1",
 				"sqlite3": ">=5"
 			},
@@ -2323,6 +1835,9 @@
 				"@types/pg": {
 					"optional": true
 				},
+				"@types/react": {
+					"optional": true
+				},
 				"@types/sql.js": {
 					"optional": true
 				},
@@ -2333,6 +1848,9 @@
 					"optional": true
 				},
 				"bun-types": {
+					"optional": true
+				},
+				"expo-sqlite": {
 					"optional": true
 				},
 				"knex": {
@@ -2348,6 +1866,9 @@
 					"optional": true
 				},
 				"postgres": {
+					"optional": true
+				},
+				"react": {
 					"optional": true
 				},
 				"sql.js": {
@@ -2380,21 +1901,6 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/duplexer2/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/duplexer2/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/eastasianwidth": {
@@ -2471,6 +1977,18 @@
 			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/esbuild": {
@@ -2680,9 +2198,9 @@
 			}
 		},
 		"node_modules/focus-trap": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-			"integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+			"integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
 			"dev": true,
 			"dependencies": {
 				"tabbable": "^6.2.0"
@@ -3161,9 +2679,10 @@
 			}
 		},
 		"node_modules/kysely": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.26.3.tgz",
-			"integrity": "sha512-yWSgGi9bY13b/W06DD2OCDDHQmq1kwTGYlQ4wpZkMOJqMGCstVCFIvxCCVG4KfY1/3G0MhDAcZsip/Lw8/vJWw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.27.2.tgz",
+			"integrity": "sha512-DmRvEfiR/NLpgsTbSxma2ldekhsdcd65+MNiKXyd/qj7w7X5e3cLkXxcj+MypsRDjPhHQ/CD5u3Eq1sBYzX0bw==",
+			"peer": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -3193,21 +2712,6 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/lazystream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/lazystream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/listenercount": {
@@ -3392,9 +2896,9 @@
 			}
 		},
 		"node_modules/minisearch": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.1.0.tgz",
-			"integrity": "sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
+			"integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ==",
 			"dev": true
 		},
 		"node_modules/mitt": {
@@ -3455,9 +2959,9 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-			"integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.4.tgz",
+			"integrity": "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==",
 			"funding": [
 				{
 					"type": "github",
@@ -3468,7 +2972,7 @@
 				"nanoid": "bin/nanoid.js"
 			},
 			"engines": {
-				"node": "^14 || ^16 || >=18"
+				"node": "^18 || >=20"
 			}
 		},
 		"node_modules/netmask": {
@@ -3719,9 +3223,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.32",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-			"integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+			"version": "8.4.33",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+			"integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3765,9 +3269,9 @@
 			}
 		},
 		"node_modules/preact": {
-			"version": "10.16.0",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
-			"integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
+			"version": "10.19.3",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+			"integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
 			"dev": true,
 			"funding": {
 				"type": "opencollective",
@@ -3775,15 +3279,15 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+			"integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
 			"dev": true,
 			"bin": {
-				"prettier": "bin-prettier.js"
+				"prettier": "bin/prettier.cjs"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
@@ -4173,22 +3677,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/rollup": {
-			"version": "3.26.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.0.tgz",
-			"integrity": "sha512-YzJH0eunH2hr3knvF3i6IkLO/jTjAEwU4HoMUbQl4//Tnl3ou0e7P5SjxdDr8HQJdeUJShlbEHXrrnEHy1l7Yg==",
-			"dev": true,
-			"bin": {
-				"rollup": "dist/bin/rollup"
-			},
-			"engines": {
-				"node": ">=14.18.0",
-				"npm": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
-			}
-		},
 		"node_modules/safaridriver": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-0.1.2.tgz",
@@ -4196,34 +3684,17 @@
 			"dev": true
 		},
 		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"node_modules/search-insights": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.7.0.tgz",
-			"integrity": "sha512-GLbVaGgzYEKMvuJbHRhLi1qoBFnjXZGZ6l4LxOYPCp4lI2jDRB3jPU9/XNhMwv6kvnA9slTreq6pvK+b3o3aqg==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
+			"integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
 			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=8.16.0"
-			}
+			"peer": true
 		},
 		"node_modules/serialize-error": {
 			"version": "11.0.3",
@@ -4267,16 +3738,28 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/shiki": {
-			"version": "0.14.3",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
-			"integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
+		"node_modules/shikiji": {
+			"version": "0.9.19",
+			"resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.19.tgz",
+			"integrity": "sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==",
 			"dev": true,
 			"dependencies": {
-				"ansi-sequence-parser": "^1.1.0",
-				"jsonc-parser": "^3.2.0",
-				"vscode-oniguruma": "^1.7.0",
-				"vscode-textmate": "^8.0.0"
+				"shikiji-core": "0.9.19"
+			}
+		},
+		"node_modules/shikiji-core": {
+			"version": "0.9.19",
+			"resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.19.tgz",
+			"integrity": "sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw==",
+			"dev": true
+		},
+		"node_modules/shikiji-transformers": {
+			"version": "0.9.19",
+			"resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.19.tgz",
+			"integrity": "sha512-lGLI7Z8frQrIBbhZ74/eiJtxMoCQRbpaHEB+gcfvdIy+ZFaAtXncJGnc52932/UET+Y4GyKtwwC/vjWUCp+c/Q==",
+			"dev": true,
+			"dependencies": {
+				"shikiji": "0.9.19"
 			}
 		},
 		"node_modules/siginfo": {
@@ -4406,12 +3889,12 @@
 			}
 		},
 		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"dependencies": {
-				"safe-buffer": "~5.2.0"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string-width": {
@@ -4726,21 +4209,6 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
-		"node_modules/unzipper/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/unzipper/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/userhome": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
@@ -4863,469 +4331,39 @@
 			}
 		},
 		"node_modules/vitepress": {
-			"version": "1.0.0-beta.5",
-			"resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-beta.5.tgz",
-			"integrity": "sha512-/RjqqRsSEKkzF6HhK5e5Ij+bZ7ETb9jNCRRgIMm10gJ+ZLC3D1OqkE465lEqCeJUgt2HZ6jmWjDqIBfrJSpv7w==",
+			"version": "1.0.0-rc.39",
+			"resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.39.tgz",
+			"integrity": "sha512-EcgoRlAAp37WOxUOYv45oxyhLrcy3Upey+mKpqW3ldsg6Ol4trPndRBk2GO0QiSvEKlb9BMerk49D/bFICN6kg==",
 			"dev": true,
 			"dependencies": {
-				"@docsearch/css": "^3.5.1",
-				"@docsearch/js": "^3.5.1",
-				"@vitejs/plugin-vue": "^4.2.3",
-				"@vue/devtools-api": "^6.5.0",
-				"@vueuse/core": "^10.2.1",
-				"@vueuse/integrations": "^10.2.1",
-				"body-scroll-lock": "4.0.0-beta.0",
-				"focus-trap": "^7.4.3",
+				"@docsearch/css": "^3.5.2",
+				"@docsearch/js": "^3.5.2",
+				"@types/markdown-it": "^13.0.7",
+				"@vitejs/plugin-vue": "^5.0.3",
+				"@vue/devtools-api": "^6.5.1",
+				"@vueuse/core": "^10.7.2",
+				"@vueuse/integrations": "^10.7.2",
+				"focus-trap": "^7.5.4",
 				"mark.js": "8.11.1",
-				"minisearch": "^6.1.0",
-				"shiki": "^0.14.3",
-				"vite": "4.4.0-beta.3",
-				"vue": "^3.3.4"
+				"minisearch": "^6.3.0",
+				"shikiji": "^0.9.19",
+				"shikiji-core": "^0.9.19",
+				"shikiji-transformers": "^0.9.19",
+				"vite": "^5.0.11",
+				"vue": "^3.4.14"
 			},
 			"bin": {
 				"vitepress": "bin/vitepress.js"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/android-arm": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.13.tgz",
-			"integrity": "sha512-KwqFhxRFMKZINHzCqf8eKxE0XqWlAVPRxwy6rc7CbVFxzUWB2sA/s3hbMZeemPdhN3fKBkqOaFhTbS8xJXYIWQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/android-arm64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.13.tgz",
-			"integrity": "sha512-j7NhycJUoUAG5kAzGf4fPWfd17N6SM3o1X6MlXVqfHvs2buFraCJzos9vbeWjLxOyBKHyPOnuCuipbhvbYtTAg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/android-x64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.13.tgz",
-			"integrity": "sha512-M2eZkRxR6WnWfVELHmv6MUoHbOqnzoTVSIxgtsyhm/NsgmL+uTmag/VVzdXvmahak1I6sOb1K/2movco5ikDJg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.13.tgz",
-			"integrity": "sha512-f5goG30YgR1GU+fxtaBRdSW3SBG9pZW834Mmhxa6terzcboz7P2R0k4lDxlkP7NYRIIdBbWp+VgwQbmMH4yV7w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/darwin-x64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.13.tgz",
-			"integrity": "sha512-RIrxoKH5Eo+yE5BtaAIMZaiKutPhZjw+j0OCh8WdvKEKJQteacq0myZvBDLU+hOzQOZWJeDnuQ2xgSScKf1Ovw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.13.tgz",
-			"integrity": "sha512-AfRPhHWmj9jGyLgW/2FkYERKmYR+IjYxf2rtSLmhOrPGFh0KCETFzSjx/JX/HJnvIqHt/DRQD/KAaVsUKoI3Xg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.13.tgz",
-			"integrity": "sha512-pGzWWZJBInhIgdEwzn8VHUBang8UvFKsvjDkeJ2oyY5gZtAM6BaxK0QLCuZY+qoj/nx/lIaItH425rm/hloETA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-arm": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.13.tgz",
-			"integrity": "sha512-4iMxLRMCxGyk7lEvkkvrxw4aJeC93YIIrfbBlUJ062kilUUnAiMb81eEkVvCVoh3ON283ans7+OQkuy1uHW+Hw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-arm64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.13.tgz",
-			"integrity": "sha512-hCzZbVJEHV7QM77fHPv2qgBcWxgglGFGCxk6KfQx6PsVIdi1u09X7IvgE9QKqm38OpkzaAkPnnPqwRsltvLkIQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-ia32": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.13.tgz",
-			"integrity": "sha512-I3OKGbynl3AAIO6onXNrup/ttToE6Rv2XYfFgLK/wnr2J+1g+7k4asLrE+n7VMhaqX+BUnyWkCu27rl+62Adug==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-loong64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.13.tgz",
-			"integrity": "sha512-8pcKDApAsKc6WW51ZEVidSGwGbebYw2qKnO1VyD8xd6JN0RN6EUXfhXmDk9Vc4/U3Y4AoFTexQewQDJGsBXBpg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.13.tgz",
-			"integrity": "sha512-6GU+J1PLiVqWx8yoCK4Z0GnfKyCGIH5L2KQipxOtbNPBs+qNDcMJr9euxnyJ6FkRPyMwaSkjejzPSISD9hb+gg==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.13.tgz",
-			"integrity": "sha512-pfn/OGZ8tyR8YCV7MlLl5hAit2cmS+j/ZZg9DdH0uxdCoJpV7+5DbuXrR+es4ayRVKIcfS9TTMCs60vqQDmh+w==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.13.tgz",
-			"integrity": "sha512-aIbhU3LPg0lOSCfVeGHbmGYIqOtW6+yzO+Nfv57YblEK01oj0mFMtvDJlOaeAZ6z0FZ9D13oahi5aIl9JFphGg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-s390x": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.13.tgz",
-			"integrity": "sha512-Pct1QwF2sp+5LVi4Iu5Y+6JsGaV2Z2vm4O9Dd7XZ5tKYxEHjFtb140fiMcl5HM1iuv6xXO8O1Vrb1iJxHlv8UA==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/linux-x64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.13.tgz",
-			"integrity": "sha512-zTrIP0KzYP7O0+3ZnmzvUKgGtUvf4+piY8PIO3V8/GfmVd3ZyHJGz7Ht0np3P1wz+I8qJ4rjwJKqqEAbIEPngA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.13.tgz",
-			"integrity": "sha512-I6zs10TZeaHDYoGxENuksxE1sxqZpCp+agYeW039yqFwh3MgVvdmXL5NMveImOC6AtpLvE4xG5ujVic4NWFIDQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.13.tgz",
-			"integrity": "sha512-W5C5nczhrt1y1xPG5bV+0M12p2vetOGlvs43LH8SopQ3z2AseIROu09VgRqydx5qFN7y9qCbpgHLx0kb0TcW7g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/sunos-x64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.13.tgz",
-			"integrity": "sha512-X/xzuw4Hzpo/yq3YsfBbIsipNgmsm8mE/QeWbdGdTTeZ77fjxI2K0KP3AlhZ6gU3zKTw1bKoZTuKLnqcJ537qw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/win32-arm64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.13.tgz",
-			"integrity": "sha512-4CGYdRQT/ILd+yLLE5i4VApMPfGE0RPc/wFQhlluDQCK09+b4JDbxzzjpgQqTPrdnP7r5KUtGVGZYclYiPuHrw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/win32-ia32": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.13.tgz",
-			"integrity": "sha512-D+wKZaRhQI+MUGMH+DbEr4owC2D7XnF+uyGiZk38QbgzLcofFqIOwFs7ELmIeU45CQgfHNy9Q+LKW3cE8g37Kg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/@esbuild/win32-x64": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.13.tgz",
-			"integrity": "sha512-iVl6lehAfJS+VmpF3exKpNQ8b0eucf5VWfzR8S7xFve64NBNz2jPUgx1X93/kfnkfgP737O+i1k54SVQS7uVZA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitepress/node_modules/esbuild": {
-			"version": "0.18.13",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.13.tgz",
-			"integrity": "sha512-vhg/WR/Oiu4oUIkVhmfcc23G6/zWuEQKFS+yiosSHe4aN6+DQRXIfeloYGibIfVhkr4wyfuVsGNLr+sQU1rWWw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"optionalDependencies": {
-				"@esbuild/android-arm": "0.18.13",
-				"@esbuild/android-arm64": "0.18.13",
-				"@esbuild/android-x64": "0.18.13",
-				"@esbuild/darwin-arm64": "0.18.13",
-				"@esbuild/darwin-x64": "0.18.13",
-				"@esbuild/freebsd-arm64": "0.18.13",
-				"@esbuild/freebsd-x64": "0.18.13",
-				"@esbuild/linux-arm": "0.18.13",
-				"@esbuild/linux-arm64": "0.18.13",
-				"@esbuild/linux-ia32": "0.18.13",
-				"@esbuild/linux-loong64": "0.18.13",
-				"@esbuild/linux-mips64el": "0.18.13",
-				"@esbuild/linux-ppc64": "0.18.13",
-				"@esbuild/linux-riscv64": "0.18.13",
-				"@esbuild/linux-s390x": "0.18.13",
-				"@esbuild/linux-x64": "0.18.13",
-				"@esbuild/netbsd-x64": "0.18.13",
-				"@esbuild/openbsd-x64": "0.18.13",
-				"@esbuild/sunos-x64": "0.18.13",
-				"@esbuild/win32-arm64": "0.18.13",
-				"@esbuild/win32-ia32": "0.18.13",
-				"@esbuild/win32-x64": "0.18.13"
-			}
-		},
-		"node_modules/vitepress/node_modules/vite": {
-			"version": "4.4.0-beta.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.4.0-beta.3.tgz",
-			"integrity": "sha512-IC/thYTvArOFRJ4qvvudnu4KKZOVc+gduS3I9OfC5SbP/Rf4kkP7z6Of2QpKeOSVqwIK24khW6VOUmVD/0yzSQ==",
-			"dev": true,
-			"dependencies": {
-				"esbuild": "^0.18.6",
-				"postcss": "^8.4.24",
-				"rollup": "^3.25.2"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@types/node": ">= 14",
-				"less": "*",
-				"lightningcss": "^1.21.0",
-				"sass": "*",
-				"stylus": "*",
-				"sugarss": "*",
-				"terser": "^5.4.0"
+				"markdown-it-mathjax3": "^4.3.2",
+				"postcss": "^8.4.33"
 			},
 			"peerDependenciesMeta": {
-				"@types/node": {
+				"markdown-it-mathjax3": {
 					"optional": true
 				},
-				"less": {
-					"optional": true
-				},
-				"lightningcss": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
+				"postcss": {
 					"optional": true
 				}
 			}
@@ -5396,29 +4434,25 @@
 				}
 			}
 		},
-		"node_modules/vscode-oniguruma": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-			"dev": true
-		},
-		"node_modules/vscode-textmate": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-			"dev": true
-		},
 		"node_modules/vue": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-			"integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.4.15.tgz",
+			"integrity": "sha512-jC0GH4KkWLWJOEQjOpkqU1bQsBwf4R1rsFtw5GQJbjHVKWDzO6P0nWWBTmjp1xSemAioDFj1jdaK1qa3DnMQoQ==",
 			"dev": true,
 			"dependencies": {
-				"@vue/compiler-dom": "3.3.4",
-				"@vue/compiler-sfc": "3.3.4",
-				"@vue/runtime-dom": "3.3.4",
-				"@vue/server-renderer": "3.3.4",
-				"@vue/shared": "3.3.4"
+				"@vue/compiler-dom": "3.4.15",
+				"@vue/compiler-sfc": "3.4.15",
+				"@vue/runtime-dom": "3.4.15",
+				"@vue/server-renderer": "3.4.15",
+				"@vue/shared": "3.4.15"
+			},
+			"peerDependencies": {
+				"typescript": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/wait-port": {

--- a/package.json
+++ b/package.json
@@ -36,16 +36,18 @@
 	},
 	"dependencies": {
 		"@sqlite.org/sqlite-wasm": "^3.44.2-build1",
-		"kysely": "^0.26.3",
-		"nanoid": "^4.0.2"
+		"nanoid": "~5"
+	},
+	"peerDependencies": {
+		"kysely": "*"
 	},
 	"devDependencies": {
 		"@vitest/browser": "^1.2.1",
-		"drizzle-orm": "^0.29.1",
-		"prettier": "^2.8.8",
+		"drizzle-orm": "^0.29.3",
+		"prettier": "3.2.4",
 		"typescript": "^5.3.3",
 		"vite": "^5.0.12",
-		"vitepress": "^1.0.0-beta.5",
+		"vitepress": "^1.0.0-rc.39",
 		"vitest": "^1.2.1",
 		"webdriverio": "^8.28.8"
 	},


### PR DESCRIPTION
This pull request updates all dependencies in `package.json` to their latest versions. It also moves `kysely` to a [`peerDependency`](https://nodejs.org/en/blog/npm/peer-dependencies), so that developers using `sqlocal` can define which version of `kysely` they want to use.

I've also run `npm install` and `npm dedupe` to update the `package-lock.json` file.