### PR TITLE
Add first class in memory db support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -45,7 +45,10 @@ export class SQLocal {
 	constructor(databasePath: string);
 	constructor(config: ClientConfig);
 	constructor(config: string | ClientConfig) {
-		config = typeof config === 'string' ? { databasePath: config } : config;
+		config =
+			typeof config === 'string'
+				? { storage: { path: config, type: 'opfs' } }
+				: config;
 
 		this.worker = new Worker(new URL('./worker', import.meta.url), {
 			type: 'module',
@@ -330,7 +333,10 @@ export class SQLocal {
 	};
 
 	getDatabaseFile = async (): Promise<File> => {
-		const path = this.config.databasePath
+		if (this.config.storage.type === 'memory') {
+			throw new Error('getDatabaseFile not supported for storage type memory');
+		}
+		const path = this.config.storage.path
 			.split(/[\\/]/)
 			.filter((part) => part !== '');
 		const fileName = path.pop();

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,6 +21,7 @@ import type {
 	TransactionMessage,
 	StatementInput,
 	Transaction,
+	ExportMessage,
 } from './types.js';
 import { sqlTag } from './lib/sql-tag.js';
 import { convertRowsToObjects } from './lib/convert-rows-to-objects.js';
@@ -73,6 +74,7 @@ export class SQLocal {
 			case 'success':
 			case 'data':
 			case 'error':
+			case 'export':
 			case 'info':
 				if (message.queryKey && queries.has(message.queryKey)) {
 					const [resolve, reject] = queries.get(message.queryKey)!;
@@ -104,6 +106,7 @@ export class SQLocal {
 			| TransactionMessage
 			| DestroyMessage
 			| FunctionMessage
+			| ExportMessage
 			| ImportMessage
 			| GetInfoMessage
 		>
@@ -136,6 +139,7 @@ export class SQLocal {
 					| TransactionMessage
 					| DestroyMessage
 					| FunctionMessage
+					| ExportMessage
 					| GetInfoMessage);
 				break;
 		}
@@ -329,6 +333,16 @@ export class SQLocal {
 			return message.info;
 		} else {
 			throw new Error('The database failed to return valid information.');
+		}
+	};
+
+	getDatabaseContent = async (): Promise<Uint8Array> => {
+		const message = await this.createQuery({ type: 'export' });
+
+		if (message.type === 'export') {
+			return message.export.data;
+		} else {
+			throw new Error('The database failed to return an export.');
 		}
 	};
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,8 +49,12 @@ export type RawResultData = {
 
 // Database status
 
+export type StorageType = { type: 'memory'; dbFile: ArrayBuffer }
+	| { type: 'fs'; path: string } // needed?
+	| { type: 'opfs'; path: string };
+
 export type ClientConfig = {
-	databasePath: string;
+	storage: StorageType;
 	readOnly?: boolean;
 	verbose?: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,8 +49,8 @@ export type RawResultData = {
 
 // Database status
 
-export type StorageType = { type: 'memory'; dbFile: ArrayBuffer }
-	| { type: 'fs'; path: string } // needed?
+export type StorageType =
+	| { type: 'memory'; dbFile?: ArrayBuffer }
 	| { type: 'opfs'; path: string };
 
 export type ClientConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export type RawResultData = {
 // Database status
 
 export type StorageType =
-	| { type: 'memory'; dbFile?: ArrayBuffer }
+	| { type: 'memory'; dbContent?: ArrayBuffer }
 	| { type: 'opfs'; path: string };
 
 export type ClientConfig = {
@@ -66,6 +66,10 @@ export type DatabaseInfo = {
 	databaseSizeBytes?: number;
 	storageType?: Sqlite3StorageType;
 	persisted?: boolean;
+};
+
+export type DatabaseExport = {
+	data: Uint8Array;
 };
 
 // Worker messages
@@ -84,7 +88,8 @@ export type InputMessage =
 	| ConfigMessage
 	| ImportMessage
 	| GetInfoMessage
-	| DestroyMessage;
+	| DestroyMessage
+	| ExportMessage;
 export type QueryMessage = {
 	type: 'query';
 	queryKey: QueryKey;
@@ -118,6 +123,10 @@ export type ConfigMessage = {
 	type: 'config';
 	config: ProcessorConfig;
 };
+export type ExportMessage = {
+	type: 'export';
+	queryKey: QueryKey;
+};
 export type ImportMessage = {
 	type: 'import';
 	queryKey: QueryKey;
@@ -137,7 +146,8 @@ export type OutputMessage =
 	| ErrorMessage
 	| DataMessage
 	| CallbackMessage
-	| InfoMessage;
+	| InfoMessage
+	| ExportDataMessage;
 export type SuccessMessage = {
 	type: 'success';
 	queryKey: QueryKey;
@@ -164,6 +174,11 @@ export type InfoMessage = {
 	type: 'info';
 	queryKey: QueryKey;
 	info: DatabaseInfo;
+};
+export type ExportDataMessage = {
+	type: 'export';
+	queryKey: QueryKey;
+	export: DatabaseExport;
 };
 
 // User functions

--- a/test/get-database-content.test.ts
+++ b/test/get-database-content.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLocal } from '../src/index';
+
+describe('getDatabaseContent', () => {
+	const fileName = 'get-database-file-test.sqlite3';
+	let isOpfsTest = false;
+
+	afterEach(async () => {
+		if (!isOpfsTest) return;
+		const opfs = await navigator.storage.getDirectory();
+		await opfs.removeEntry(fileName);
+		isOpfsTest = false;
+	});
+
+	it('should return the requested database content on opfs', async () => {
+		isOpfsTest = true;
+		const { sql, getDatabaseContent, getDatabaseInfo } = new SQLocal(fileName);
+
+		await sql`CREATE TABLE nums (num REAL NOT NULL)`;
+
+		const content = await getDatabaseContent();
+		expect(content).toBeInstanceOf(Uint8Array);
+	});
+
+	it('should return the requested database content in memory', async () => {
+		const { sql, getDatabaseContent } = new SQLocal({
+			storage: {
+				type: 'memory',
+			},
+		});
+
+		await sql`CREATE TABLE nums (num REAL NOT NULL)`;
+		const content = await getDatabaseContent();
+
+		expect(content).toBeInstanceOf(Uint8Array);
+	});
+});

--- a/test/init-memory.test.ts
+++ b/test/init-memory.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SQLocal } from '../src/index';
+
+describe('init', () => {
+	const { sql,  } = new SQLocal({
+		storage: {
+			type: 'memory',
+		},
+	});
+	
+	let dbContent = 
+
+	beforeEach(async () => {
+		console.log('memory');
+		await sql`CREATE TABLE nums (num INTEGER NOT NULL)`;
+		console.log('memory2');
+		await sql`INSERT INTO nums (num) VALUES (0)`;
+	});
+
+	afterEach(async () => {
+		await sql`DROP TABLE nums`;
+	});
+
+	it('should enable read-only mode', async () => {
+		const { sql, destroy } = new SQLocal({
+			storage: {
+				type: 'memory',
+			},
+			readOnly: true,
+		});
+
+		const write = async () => {
+			await sql`INSERT INTO nums (num) VALUES (1)`;
+		};
+		expect(write).rejects.toThrowError(
+			'SQLITE_IOERR_WRITE: sqlite3 result code 778: disk I/O error'
+		);
+
+		const read = async () => {
+			return await sql`SELECT * FROM nums`;
+		};
+		const data = await read();
+		expect(data).toEqual([{ num: 0 }]);
+
+		await destroy();
+	});
+});

--- a/test/init-memory.test.ts
+++ b/test/init-memory.test.ts
@@ -1,20 +1,21 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index';
 
-describe('init', () => {
-	const { sql,  } = new SQLocal({
+describe('init', async () => {
+	const { sql, getDatabaseContent } = new SQLocal({
 		storage: {
 			type: 'memory',
 		},
 	});
-	
-	let dbContent = 
+
+	let dbContent;
 
 	beforeEach(async () => {
 		console.log('memory');
 		await sql`CREATE TABLE nums (num INTEGER NOT NULL)`;
 		console.log('memory2');
 		await sql`INSERT INTO nums (num) VALUES (0)`;
+		dbContent = await getDatabaseContent();
 	});
 
 	afterEach(async () => {
@@ -25,15 +26,18 @@ describe('init', () => {
 		const { sql, destroy } = new SQLocal({
 			storage: {
 				type: 'memory',
+				dbContent: dbContent,
 			},
 			readOnly: true,
 		});
 
+		console.log('sending insert');
 		const write = async () => {
 			await sql`INSERT INTO nums (num) VALUES (1)`;
 		};
+
 		expect(write).rejects.toThrowError(
-			'SQLITE_IOERR_WRITE: sqlite3 result code 778: disk I/O error'
+			'SQLITE_READONLY: sqlite3 result code 8: attempt to write a readonly database'
 		);
 
 		const read = async () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -3,7 +3,7 @@ import { SQLocal } from '../src/index';
 
 describe('init', () => {
 	const databasePath = 'init-test.sqlite3';
-	const { sql } = new SQLocal({ databasePath });
+	const { sql } = new SQLocal(databasePath);
 
 	beforeEach(async () => {
 		await sql`CREATE TABLE nums (num INTEGER NOT NULL)`;
@@ -32,7 +32,10 @@ describe('init', () => {
 
 	it('should enable read-only mode', async () => {
 		const { sql, destroy } = new SQLocal({
-			databasePath,
+			storage: {
+				path: databasePath,
+				type: 'opfs',
+			},
 			readOnly: true,
 		});
 

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -13,6 +13,7 @@ describe('transaction', () => {
 	afterEach(async () => {
 		await sql`DROP TABLE groceries`;
 		await sql`DROP TABLE prices`;
+		
 	});
 
 	it('should perform successful transaction', async () => {


### PR DESCRIPTION
Hey @DallasHoff,

Thank you for your great work on SQLocal!

We are using your library in combination with Kysely for our latest projects at Lix and Inlang. Our applications run in various environments, and not all of them support OPFS. In such cases, we would love to explicitly run in memory rather than implicitly falling back to it. Additionally, there are scenarios where we explicitly want to use SQLite in memory, such as when we want to create a database without immediately materializing it:

[Relevant Code in Our Project](https://github.com/opral/monorepo/blob/66f6b5764fb1efa70054db74f5a918cb0cd90ce5/inlang/source-code/sdk-v2/src/newProjectOpfs.ts#L33)

This PR changes the SQLocal constructor to accept a storage property instead of databasePath. See the changes [here](https://github.com/DallasHoff/sqlocal/compare/main...opral:sqlocal:memory-support#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR57).

This allows the library to initialize in memory mode.

For a memory database, asking for a database file doesn't make sense. Therefore, this PR also introduces a new method, getDatabaseContent, which allows exporting the database. See the method implementation [here](https://github.com/DallasHoff/sqlocal/compare/main...opral:sqlocal:memory-support#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R339).

Some parts might need further refinement. Please let me know if you are interested in supporting these additions to your library. If so, I am happy to provide further assistance to get this merged.

Best regards,
Martin from opral.com/inlang.com

 



