### PR TITLE
Defer starting Worker if not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# About this fork
+
+This fork is a temporary fork of the original [sqlocal](https://github.com/DallasHoff/sqlocal) package
+to support frameworks that pre-renders at build time where `Worker` is not defined.
+
+Other than minor dependency updates, the only changes are:
+
+- `SQLocal` won't try to start the Worker if `Worker` is not defined.
+- new `startWorker` function added to `SQLocal` to be called from client-side where Worker can be started.
+
 # SQLocal
 
 SQLocal makes it easy to run SQLite3 in the browser, backed by the origin private file system. It wraps the [WebAssembly build of SQLite3](https://sqlite.org/wasm/doc/trunk/index.md) and gives you a simple interface to interact with databases running on device.

--- a/package.json
+++ b/package.json
@@ -45,16 +45,16 @@
 	"devDependencies": {
 		"@vitest/browser": "^2.0.5",
 		"@vitest/ui": "^2.0.5",
-		"drizzle-orm": "^0.31.2",
+		"drizzle-orm": "^0.33.0",
 		"kysely": "^0.27.4",
-		"prettier": "^3.3.2",
-		"taze": "^0.14.2",
-		"typescript": "^5.5.3",
-		"vite": "^5.3.5",
-		"vitepress": "^1.2.3",
+		"prettier": "^3.3.3",
+		"taze": "^0.16.6",
+		"typescript": "^5.5.4",
+		"vite": "^5.4.1",
+		"vitepress": "^1.3.3",
 		"vitest": "^2.0.5",
 		"webdriverio": "^8.39.1",
-		"wrangler": "^3.63.1"
+		"wrangler": "^3.72.0"
 	},
 	"peerDependencies": {
 		"drizzle-orm": "*",


### PR DESCRIPTION
## Why

Drizzle's fancy schema support (Drizzle Query) seems to require schema to be defined at (Next.js) pre-render time. Deferring `db` singleton instance creation breaks `db.query.{table}.findXXX` at build time.

This PR adds `startWorker` function which won't start the Worker when it can't (`Worker` is not defined).

## Usage

Initialization

```ts
// sqlite proxy to sqlite wasm worker
// NOTE: sqlocal throws Worker undefined error here during build but not with this fork.
const { startWorker, driver, batchDriver, batch, transaction } = new SQLocalDrizzle({
  databasePath: 'newspond.sqlite3',
  readOnly: false,
  verbose: true,
})
// connect to database and initialize schema if missing
// NOTE: `schema` passed here enables `db.query.{table}` calls.
const db = drizzle(driver, batchDriver, { schema })
```

`startWorker` should be called from the client-side just before creating tables and indexes.