### PR TITLE
Start Worker when it can

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -47,10 +47,6 @@ export class SQLocal {
 	constructor(config: string | ClientConfig) {
 		this.config = typeof config === 'string' ? { databasePath: config } : config;
 
-		this.startWorker();
-	}
-
-	startWorker = async (): Promise<void> => {
 		if (!this.worker && typeof globalThis.Worker !== 'undefined') {
 			this.worker = new Worker(new URL('./worker', import.meta.url), {
 				type: 'module',
@@ -110,6 +106,11 @@ export class SQLocal {
 			| GetInfoMessage
 		>
 	): Promise<OutputMessage> => {
+		if (!this.worker) {
+			throw new Error(
+				'This SQLocal client does not have a worker. This is likely due to SSR or worker failing to initialize.'
+			)
+		}
 		if (this.isWorkerDestroyed === true) {
 			throw new Error(
 				'This SQLocal client has been destroyed. You will need to initialize a new client in order to make further queries.'

--- a/src/client.ts
+++ b/src/client.ts
@@ -108,9 +108,10 @@ export class SQLocal {
 	): Promise<OutputMessage> => {
 		if (!this.worker) {
 			throw new Error(
-				'This SQLocal client does not have a worker. This is likely due to SSR or worker failing to initialize.'
+				'This SQLocal client is not connected to a database. This is likely due to the client being initialized in a server-side environment.'
 			)
 		}
+
 		if (this.isWorkerDestroyed === true) {
 			throw new Error(
 				'This SQLocal client has been destroyed. You will need to initialize a new client in order to make further queries.'
@@ -121,7 +122,7 @@ export class SQLocal {
 
 		switch (message.type) {
 			case 'import':
-				this.worker?.postMessage(
+				this.worker.postMessage(
 					{
 						...message,
 						queryKey,
@@ -130,7 +131,7 @@ export class SQLocal {
 				);
 				break;
 			default:
-				this.worker?.postMessage({
+				this.worker.postMessage({
 					...message,
 					queryKey,
 				} satisfies

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,7 +47,7 @@ export class SQLocal {
 	constructor(config: string | ClientConfig) {
 		this.config = typeof config === 'string' ? { databasePath: config } : config;
 
-		if (!this.worker && typeof globalThis.Worker !== 'undefined') {
+		if (typeof globalThis.Worker !== 'undefined') {
 			this.worker = new Worker(new URL('./worker', import.meta.url), {
 				type: 'module',
 			});


### PR DESCRIPTION
## Why

Drizzle's fancy schema support (Drizzle Query) seems to require schema to be defined at (Next.js) pre-render time. Deferring `db` singleton instance creation breaks `db.query.{table}.findXXX` at build time.

This PR adds `startWorker` function which won't start the Worker when it can't (`Worker` is not defined).

## Usage

Initialization

```ts
// sqlite proxy to sqlite wasm worker
// NOTE: sqlocal throws Worker undefined error here during build but not with this fork.
const { startWorker, driver, batchDriver, batch, transaction } = new SQLocalDrizzle({
  databasePath: 'newspond.sqlite3',
  readOnly: false,
  verbose: true,
})
// connect to database and initialize schema if missing
// NOTE: `schema` passed here enables `db.query.{table}` calls.
const db = drizzle(driver, batchDriver, { schema })
```

`startWorker` should be called from the client-side just before creating tables and indexes.