### PR TITLE
Add failing concurrent transaction test

### DIFF
--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -73,4 +73,18 @@ describe('transaction', () => {
 		expect(data).toEqual([{ name: 'x' }, { name: 'x' }]);
 		expect(order).toEqual([1, 2, 3]);
 	});
+
+	it('can complete concurrent transactions', async () => {
+		const promise = Promise.all([
+			transaction(async (tx) => {
+				await tx.sql`SELECT * FROM groceries`;
+				await sleep(100);
+			}),
+			transaction(async (tx) => {
+				await tx.sql`SELECT * FROM groceries`;
+			}),
+		]);
+
+		await expect(promise).resolves.toHaveLength(2);
+	});
 });


### PR DESCRIPTION
https://github.com/DallasHoff/sqlocal/issues/45

Heads up: This test does timeout, but when I ran it, the timeouts were pretty long: 15 seconds for the test, and 30 seconds for the `afterEach` hook.