### PR TITLE
Skip begin-transaction lock if already acquired

### DIFF
--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -73,4 +73,18 @@ describe('transaction', () => {
 		expect(data).toEqual([{ name: 'x' }, { name: 'x' }]);
 		expect(order).toEqual([1, 2, 3]);
 	});
+
+	it('can complete concurrent transactions', async () => {
+		const promise = Promise.all([
+			transaction(async (tx) => {
+				await tx.sql`SELECT * FROM groceries`;
+				await sleep(100);
+			}),
+			transaction(async (tx) => {
+				await tx.sql`SELECT * FROM groceries`;
+			}),
+		]);
+
+		await expect(promise).resolves.toHaveLength(2);
+	});
 });


### PR DESCRIPTION
This is my quick and dirty fix to #45 which passes the test added in #46 – opened this as a separate PR because I bet I'm missing some better way to do this (e.g. maybe it's better just to never attempt to take the lock twice in the same `postMessage`?).