### PR TITLE
remove: nanoid in favor of crypto.randomUUID()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@sqlite.org/sqlite-wasm": "^3.46.0-build2",
-				"coincident": "^1.2.3",
-				"nanoid": "^5.0.7"
+				"coincident": "^1.2.3"
 			},
 			"devDependencies": {
 				"@vitest/browser": "^2.0.5",
@@ -5332,23 +5331,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/nanoid": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
-			"integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
 			}
 		},
 		"node_modules/netmask": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
 	},
 	"dependencies": {
 		"@sqlite.org/sqlite-wasm": "^3.46.0-build2",
-		"coincident": "^1.2.3",
-		"nanoid": "^5.0.7"
+		"coincident": "^1.2.3"
 	},
 	"devDependencies": {
 		"@vitest/browser": "^2.0.5",

--- a/src/lib/get-query-key.ts
+++ b/src/lib/get-query-key.ts
@@ -1,6 +1,5 @@
-import { nanoid } from 'nanoid';
 import type { QueryKey } from '../types.js';
 
 export function getQueryKey(): QueryKey {
-	return nanoid();
+	return crypto.randomUUID();
 }


### PR DESCRIPTION
Hey! Firstly, thanks a lot for the work done on this package! So far, it was super straightforward & easy to use 😄

I noticed only 3 dependencies were present, one of them "nanoid". Maybe there's a good reason for it, but `crypto.randomUUID()` is available as a web standard now and has [great browser support](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID), so I thought we could use it instead & lose 1 dependency, although small and battletested. You never know when someone will push malicious code on a trusted dependency, so this one looked like an easy win 😅.

If there's a good reason to continue using `nanoid`, then by all means disregard this PR! Otherwise, let me know if other changes are needed! 👍🏻 

Cheers!