### PR TITLE
remove: nanoid in favor of crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@sqlite.org/sqlite-wasm": "^3.46.1-build5",
-				"coincident": "^1.2.3",
-				"nanoid": "^5.0.7"
+				"coincident": "^1.2.3"
 			},
 			"devDependencies": {
 				"@vitest/browser": "^2.0.5",
@@ -5332,23 +5331,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/nanoid": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
-			"integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
 			}
 		},
 		"node_modules/netmask": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
 	},
 	"dependencies": {
 		"@sqlite.org/sqlite-wasm": "^3.46.1-build5",
-		"coincident": "^1.2.3",
-		"nanoid": "^5.0.7"
+		"coincident": "^1.2.3"
 	},
 	"devDependencies": {
 		"@vitest/browser": "^2.0.5",

--- a/src/lib/get-query-key.ts
+++ b/src/lib/get-query-key.ts
@@ -1,6 +1,5 @@
-import { nanoid } from 'nanoid';
 import type { QueryKey } from '../types.js';
 
 export function getQueryKey(): QueryKey {
-	return nanoid();
+	return crypto.randomUUID();
 }


### PR DESCRIPTION
Same PR as #49 

TL:DR - `crypto.randomUUID()` used instead of `nanoid`, since `sqlite-wasm` already uses a secure context by default.