### PR TITLE
Full in-memory database support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -38,7 +38,7 @@ import { normalizeDatabaseFile } from './lib/normalize-database-file.js';
 export class SQLocal {
 	protected config: ClientConfig;
 	protected clientKey: QueryKey;
-	protected processor?: SQLocalProcessor | Worker;
+	protected processor: SQLocalProcessor | Worker;
 	protected isDestroyed: boolean = false;
 	protected bypassMutationLock: boolean = false;
 	protected userCallbacks = new Map<string, CallbackUserFunction['func']>();
@@ -50,7 +50,7 @@ export class SQLocal {
 		]
 	>();
 
-	protected proxy?: WorkerProxy;
+	protected proxy: WorkerProxy;
 	protected reinitChannel: BroadcastChannel;
 
 	constructor(databasePath: DatabasePath);
@@ -148,12 +148,6 @@ export class SQLocal {
 				message.type === 'delete',
 			this.config,
 			async () => {
-				if (!this.processor) {
-					throw new Error(
-						'This SQLocal client is not connected to a database. This is likely due to the client being initialized in a server-side environment.'
-					);
-				}
-
 				if (this.isDestroyed === true) {
 					throw new Error(
 						'This SQLocal client has been destroyed. You will need to initialize a new client in order to make further queries.'
@@ -381,7 +375,7 @@ export class SQLocal {
 			functionType: 'scalar',
 		});
 
-		if (this.proxy && this.proxy !== globalThis) {
+		if (this.proxy !== globalThis) {
 			this.proxy[key] = func;
 		}
 	};

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,7 @@ import { getQueryKey } from './lib/get-query-key.js';
 import { normalizeSql } from './lib/normalize-sql.js';
 import { parseDatabasePath } from './lib/parse-database-path.js';
 import { mutationLock } from './lib/mutation-lock.js';
+import { normalizeDatabaseFile } from './lib/normalize-database-file.js';
 
 export class SQLocal {
 	protected config: ClientConfig;
@@ -435,16 +436,10 @@ export class SQLocal {
 			| ReadableStream<Uint8Array>,
 		beforeUnlock?: () => void | Promise<void>
 	): Promise<void> => {
-		let database: ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>;
-
-		if (databaseFile instanceof Blob) {
-			database = databaseFile.stream();
-		} else {
-			database = databaseFile;
-		}
-
 		await mutationLock('exclusive', false, this.config, async () => {
 			try {
+				const database = await normalizeDatabaseFile(databaseFile);
+
 				await this.createQuery({
 					type: 'import',
 					database,

--- a/src/client.ts
+++ b/src/client.ts
@@ -66,7 +66,11 @@ export class SQLocal {
 			`_sqlocal_reinit_(${clientConfig.databasePath})`
 		);
 
-		if (typeof globalThis.Worker !== 'undefined') {
+		if (processorConfig.databasePath === ':memory:') {
+			this.processor = new SQLocalProcessor(true);
+			this.processor.onmessage = (message) => this.processMessageEvent(message);
+			this.proxy = globalThis as WorkerProxy;
+		} else if (typeof globalThis.Worker !== 'undefined') {
 			this.processor = new Worker(new URL('./worker', import.meta.url), {
 				type: 'module',
 			});

--- a/src/lib/normalize-database-file.ts
+++ b/src/lib/normalize-database-file.ts
@@ -1,0 +1,74 @@
+type DatabaseFileInput =
+	| File
+	| Blob
+	| ArrayBuffer
+	| Uint8Array
+	| ReadableStream<Uint8Array>;
+
+export function normalizeDatabaseFile(
+	dbFile: DatabaseFileInput,
+	convertStreamTo: 'callback'
+): Promise<ArrayBuffer | Uint8Array | (() => Promise<Uint8Array | undefined>)>;
+export function normalizeDatabaseFile(
+	dbFile: DatabaseFileInput,
+	convertStreamTo: 'buffer'
+): Promise<ArrayBuffer | Uint8Array>;
+export function normalizeDatabaseFile(
+	dbFile: DatabaseFileInput,
+	convertStreamTo?: undefined
+): Promise<ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>>;
+export async function normalizeDatabaseFile(
+	dbFile: DatabaseFileInput,
+	convertStreamTo?: 'callback' | 'buffer'
+): Promise<
+	| ArrayBuffer
+	| Uint8Array
+	| ReadableStream<Uint8Array>
+	| (() => Promise<Uint8Array | undefined>)
+> {
+	let bufferOrStream: ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>;
+
+	if (dbFile instanceof Blob) {
+		bufferOrStream = dbFile.stream();
+	} else {
+		bufferOrStream = dbFile;
+	}
+
+	if (bufferOrStream instanceof ReadableStream && convertStreamTo) {
+		const stream = bufferOrStream;
+		const reader = stream.getReader();
+
+		switch (convertStreamTo) {
+			case 'callback':
+				return async () => {
+					const chunk = await reader.read();
+					return chunk.value;
+				};
+
+			case 'buffer':
+				const chunks: Uint8Array[] = [];
+				let streamDone = false;
+
+				while (!streamDone) {
+					const chunk = await reader.read();
+					if (chunk.value) chunks.push(chunk.value);
+					streamDone = chunk.done;
+				}
+
+				const arrayLength = chunks.reduce((length, chunk) => {
+					return length + chunk.length;
+				}, 0);
+				const buffer = new Uint8Array(arrayLength);
+				let offset = 0;
+
+				chunks.forEach((chunk) => {
+					buffer.set(chunk, offset);
+					offset += chunk.length;
+				});
+
+				return buffer;
+		}
+	} else {
+		return bufferOrStream;
+	}
+}

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -40,7 +40,7 @@ export class SQLocalProcessor {
 	protected transactionKey: QueryKey | null = null;
 
 	protected proxy: WorkerProxy;
-	protected reinitChannel: BroadcastChannel | undefined;
+	protected reinitChannel?: BroadcastChannel;
 
 	onmessage?: (message: OutputMessage, transfer: Transferable[]) => void;
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -67,15 +67,18 @@ export class SQLocalProcessor {
 				this.destroy();
 			}
 
-			if ('opfs' in this.sqlite3) {
+			if ('opfs' in this.sqlite3 && databasePath !== ':memory:') {
 				this.db = new this.sqlite3.oo1.OpfsDb(databasePath, flags);
 				this.dbStorageType = 'opfs';
 			} else {
 				this.db = new this.sqlite3.oo1.DB(databasePath, flags);
 				this.dbStorageType = 'memory';
-				console.warn(
-					`The origin private file system is not available, so ${databasePath} will not be persisted. Make sure your web server is configured to use the correct HTTP response headers (See https://sqlocal.dallashoffman.com/guide/setup#cross-origin-isolation).`
-				);
+
+				if (databasePath !== ':memory:') {
+					console.warn(
+						`The origin private file system is not available, so ${databasePath} will not be persisted. Make sure your web server is configured to use the correct HTTP response headers (See https://sqlocal.dallashoffman.com/guide/setup#cross-origin-isolation).`
+					);
+				}
 			}
 
 			this.reinitChannel = new BroadcastChannel(

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export type RawResultData = {
 
 // Database status
 
-export type DatabasePath = string;
+export type DatabasePath = (string & {}) | ':memory:';
 
 export type ClientConfig = {
 	databasePath: DatabasePath;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,8 +86,9 @@ export type InputMessage =
 	| TransactionMessage
 	| FunctionMessage
 	| ConfigMessage
-	| ImportMessage
 	| GetInfoMessage
+	| ImportMessage
+	| ExportMessage
 	| DeleteMessage
 	| DestroyMessage;
 export type QueryMessage = {
@@ -123,13 +124,17 @@ export type ConfigMessage = {
 	type: 'config';
 	config: ProcessorConfig;
 };
+export type GetInfoMessage = {
+	type: 'getinfo';
+	queryKey: QueryKey;
+};
 export type ImportMessage = {
 	type: 'import';
 	queryKey: QueryKey;
 	database: ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>;
 };
-export type GetInfoMessage = {
-	type: 'getinfo';
+export type ExportMessage = {
+	type: 'export';
 	queryKey: QueryKey;
 };
 export type DeleteMessage = {
@@ -145,6 +150,7 @@ export type OutputMessage =
 	| SuccessMessage
 	| ErrorMessage
 	| DataMessage
+	| BufferMessage
 	| CallbackMessage
 	| InfoMessage
 	| EventMessage;
@@ -164,6 +170,11 @@ export type DataMessage = {
 		columns: string[];
 		rows: unknown[] | unknown[][];
 	}[];
+};
+export type BufferMessage = {
+	type: 'buffer';
+	queryKey: QueryKey;
+	buffer: Uint8Array;
 };
 export type CallbackMessage = {
 	type: 'callback';

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index.js';
 
-describe('batch', () => {
-	const { sql, batch } = new SQLocal('batch-test.sqlite3');
+describe.each([
+	{ type: 'opfs', path: 'batch-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('batch ($type)', ({ path }) => {
+	const { sql, batch } = new SQLocal(path);
 
 	beforeEach(async () => {
 		await sql`CREATE TABLE groceries (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;

--- a/test/create-callback-function.test.ts
+++ b/test/create-callback-function.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index.js';
 
-describe('createCallbackFunction', () => {
-	const { sql, createCallbackFunction } = new SQLocal(
-		'create-callback-function-test.sqlite3'
-	);
+describe.each([
+	{ type: 'opfs', path: 'create-callback-function-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('createCallbackFunction ($type)', ({ path }) => {
+	const { sql, createCallbackFunction } = new SQLocal(path);
 
 	beforeEach(async () => {
 		await sql`CREATE TABLE groceries (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;

--- a/test/create-scalar-function.test.ts
+++ b/test/create-scalar-function.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index.js';
 
-describe('createScalarFunction', () => {
-	const { sql, createScalarFunction } = new SQLocal(
-		'create-scalar-function-test.sqlite3'
-	);
+describe.each([
+	{ type: 'opfs', path: 'create-scalar-function-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('createScalarFunction ($type)', ({ path }) => {
+	const { sql, createScalarFunction } = new SQLocal(path);
 
 	beforeEach(async () => {
 		await sql`CREATE TABLE nums (num REAL NOT NULL)`;

--- a/test/delete-database-file.test.ts
+++ b/test/delete-database-file.test.ts
@@ -4,8 +4,8 @@ import { sleep } from './test-utils/sleep.js';
 
 describe.each([
 	{ type: 'opfs', path: 'delete-db-test.sqlite3' },
-	// { type: 'memory', path: ':memory:' }, // TODO
-])('deleteDatabaseFile ($type)', ({ path }) => {
+	{ type: 'memory', path: ':memory:' },
+])('deleteDatabaseFile ($type)', ({ path, type }) => {
 	it('should delete the database file', async () => {
 		let onConnectCalled = false;
 		let beforeUnlockCalled = false;
@@ -44,7 +44,7 @@ describe.each([
 		await destroy();
 	});
 
-	it('should notify other instances of a delete', async () => {
+	it('should or should not notify other instances of a delete', async () => {
 		let onConnectCalled1 = false;
 		let onConnectCalled2 = false;
 
@@ -63,10 +63,15 @@ describe.each([
 		onConnectCalled2 = false;
 
 		await db1.deleteDatabaseFile();
-		await vi.waitUntil(() => onConnectCalled2 === true);
+
+		if (type !== 'memory') {
+			await vi.waitUntil(() => onConnectCalled2 === true);
+			expect(onConnectCalled2).toBe(true);
+		} else {
+			expect(onConnectCalled2).toBe(false);
+		}
 
 		expect(onConnectCalled1).toBe(true);
-		expect(onConnectCalled2).toBe(true);
 
 		await db2.deleteDatabaseFile();
 		await db2.destroy();

--- a/test/destroy.test.ts
+++ b/test/destroy.test.ts
@@ -1,16 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index.js';
 
-describe('destroy', () => {
-	const { sql, destroy } = new SQLocal('destroy-test.sqlite3');
+describe.each([
+	{ type: 'opfs', path: 'destroy-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('destroy ($type)', ({ path }) => {
+	const { sql, destroy } = new SQLocal(path);
 
 	beforeEach(async () => {
 		await sql`CREATE TABLE groceries (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;
 	});
 
 	afterEach(async () => {
-		const { sql } = new SQLocal('destroy-test.sqlite3');
-		await sql`DROP TABLE groceries`;
+		const { sql } = new SQLocal(path);
+		await sql`DROP TABLE IF EXISTS groceries`;
 	});
 
 	it('should destroy the client', async () => {

--- a/test/drizzle/driver.test.ts
+++ b/test/drizzle/driver.test.ts
@@ -5,10 +5,11 @@ import { int, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { desc, eq, relations, sql as dsql } from 'drizzle-orm';
 import { sleep } from '../test-utils/sleep.js';
 
-describe('drizzle driver', () => {
-	const { sql, driver, batchDriver, transaction } = new SQLocalDrizzle(
-		'drizzle-driver-test.sqlite3'
-	);
+describe.each([
+	{ type: 'opfs', path: 'drizzle-driver-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('drizzle driver ($type)', ({ path }) => {
+	const { sql, driver, batchDriver, transaction } = new SQLocalDrizzle(path);
 
 	const groceries = sqliteTable('groceries', {
 		id: int('id').primaryKey({ autoIncrement: true }),

--- a/test/get-database-file.test.ts
+++ b/test/get-database-file.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index.js';
 
-describe('getDatabaseFile', () => {
-	const fileName = 'get-database-file-test.sqlite3';
+describe.each([
+	{ type: 'opfs', path: 'get-database-file-test.sqlite3' },
+	// { type: 'memory', path: ':memory:' }, // TODO
+])('getDatabaseFile ($type)', ({ path, type }) => {
+	const fileName = path;
 	const paths = [[], [''], ['top'], ['one', 'two']];
 
 	it('should return the requested database file', async () => {
@@ -27,7 +30,8 @@ describe('getDatabaseFile', () => {
 	});
 
 	it('should not throw when requested database has not been created', async () => {
-		const { getDatabaseFile } = new SQLocal('blank.sqlite3');
+		const databasePath = type === 'opfs' ? 'new.sqlite3' : path;
+		const { getDatabaseFile } = new SQLocal(databasePath);
 		await expect(getDatabaseFile()).resolves.not.toThrow();
 	});
 });

--- a/test/get-database-file.test.ts
+++ b/test/get-database-file.test.ts
@@ -3,9 +3,9 @@ import { SQLocal } from '../src/index.js';
 
 describe.each([
 	{ type: 'opfs', path: 'get-database-file-test.sqlite3' },
-	// { type: 'memory', path: ':memory:' }, // TODO
+	{ type: 'memory', path: ':memory:' },
 ])('getDatabaseFile ($type)', ({ path, type }) => {
-	const fileName = path;
+	const fileName = type !== 'opfs' ? 'database.sqlite3' : path;
 	const paths = [[], [''], ['top'], ['one', 'two']];
 
 	it('should return the requested database file', async () => {

--- a/test/get-database-info.test.ts
+++ b/test/get-database-info.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index.js';
 
-describe('getDatabaseInfo', () => {
-	const { sql, getDatabaseInfo, deleteDatabaseFile } = new SQLocal(
-		'get-database-info-test.sqlite3'
-	);
+describe.each([
+	{ type: 'opfs', path: 'get-database-info-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('getDatabaseInfo ($type)', ({ type, path }) => {
+	const { sql, getDatabaseInfo, deleteDatabaseFile } = new SQLocal(path);
 
 	afterEach(async () => {
 		await deleteDatabaseFile();
@@ -13,9 +14,9 @@ describe('getDatabaseInfo', () => {
 	it('should return information about the database', async () => {
 		const info1 = await getDatabaseInfo();
 		expect(info1).toEqual({
-			databasePath: 'get-database-info-test.sqlite3',
+			databasePath: path,
 			databaseSizeBytes: 0,
-			storageType: 'opfs',
+			storageType: type,
 			persisted: false,
 		});
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,9 +1,11 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index.js';
 
-describe('init', () => {
-	const databasePath = 'init-test.sqlite3';
-	const { sql, deleteDatabaseFile } = new SQLocal({ databasePath });
+describe.each([
+	{ type: 'opfs', path: 'init-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('init ($type)', ({ path, type }) => {
+	const { sql, deleteDatabaseFile } = new SQLocal(path);
 
 	beforeEach(async () => {
 		await sql`CREATE TABLE nums (num INTEGER NOT NULL)`;
@@ -22,31 +24,44 @@ describe('init', () => {
 		expect(crossOriginIsolated).toBe(true);
 	});
 
-	it('should create a file in the OPFS', async () => {
+	it('should or should not create a file in the OPFS', async () => {
 		const opfs = await navigator.storage.getDirectory();
-		const fileHandle = await opfs.getFileHandle(databasePath);
-		const file = await fileHandle.getFile();
-		expect(file.size).toBeGreaterThan(0);
+
+		if (type === 'opfs') {
+			const fileHandle = await opfs.getFileHandle(path);
+			const file = await fileHandle.getFile();
+			expect(file.size).toBeGreaterThan(0);
+		} else {
+			await expect(opfs.getFileHandle(path)).rejects.toThrowError();
+		}
 	});
 
 	it('should enable read-only mode', async () => {
 		const { sql, destroy } = new SQLocal({
-			databasePath,
+			databasePath: path,
 			readOnly: true,
 		});
 
-		const write = async () => {
-			await sql`INSERT INTO nums (num) VALUES (1)`;
-		};
-		await expect(write).rejects.toThrowError(
-			'SQLITE_READONLY: sqlite3 result code 8: attempt to write a readonly database'
-		);
+		const expectedError =
+			'SQLITE_READONLY: sqlite3 result code 8: attempt to write a readonly database';
 
-		const read = async () => {
-			return await sql`SELECT * FROM nums`;
-		};
-		const data = await read();
-		expect(data).toEqual([{ num: 0 }]);
+		if (type === 'memory') {
+			const write = async () => {
+				await sql`CREATE TABLE nums (num INTEGER NOT NULL)`;
+			};
+			await expect(write).rejects.toThrowError(expectedError);
+
+			const data = await sql`SELECT (2 + 2) as result`;
+			expect(data).toEqual([{ result: 4 }]);
+		} else {
+			const write = async () => {
+				await sql`INSERT INTO nums (num) VALUES (1)`;
+			};
+			await expect(write).rejects.toThrowError(expectedError);
+
+			const data = await sql`SELECT * FROM nums`;
+			expect(data).toEqual([{ num: 0 }]);
+		}
 
 		await destroy();
 	});

--- a/test/kysely/dialect.test.ts
+++ b/test/kysely/dialect.test.ts
@@ -5,10 +5,11 @@ import { jsonArrayFrom } from 'kysely/helpers/sqlite';
 import { SQLocalKysely } from '../../src/kysely/index.js';
 import { sleep } from '../test-utils/sleep.js';
 
-describe('kysely dialect', () => {
-	const { dialect, transaction } = new SQLocalKysely(
-		'kysely-dialect-test.sqlite3'
-	);
+describe.each([
+	{ type: 'opfs', path: 'kysely-dialect-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('kysely dialect ($type)', ({ path }) => {
+	const { dialect, transaction } = new SQLocalKysely(path);
 	const db = new Kysely<DB>({
 		dialect,
 		plugins: [new ParseJSONResultsPlugin()],

--- a/test/kysely/migrations.test.ts
+++ b/test/kysely/migrations.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { SQLocalKysely } from '../../src/kysely/index.js';
 import { Kysely, Migrator } from 'kysely';
 
-describe('kysely migrations', () => {
-	const databasePath = 'kysely-migrations-test.sqlite3';
-	const { dialect, deleteDatabaseFile } = new SQLocalKysely(databasePath);
+describe.each([
+	{ type: 'opfs', path: 'kysely-migrations-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('kysely migrations ($type)', ({ path }) => {
+	const { dialect, deleteDatabaseFile } = new SQLocalKysely(path);
 	const db = new Kysely({ dialect });
 
 	const migrator = new Migrator({

--- a/test/sql.test.ts
+++ b/test/sql.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SQLocal } from '../src/index.js';
 
-describe('sql', () => {
-	const { sql } = new SQLocal('sql-test.sqlite3');
+describe.each([
+	{ type: 'opfs', path: 'sql-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+])('sql ($type)', ({ path }) => {
+	const { sql } = new SQLocal(path);
 
 	beforeEach(async () => {
 		await sql`CREATE TABLE groceries (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;


### PR DESCRIPTION
Implements support for initializing SQLocal with an in-memory database.

```js
new SQLocal(':memory:')
```

SQLocal would previously fall back to using an in-memory database if OPFS was not supported, but these changes give the option of using in-memory mode explicitly and add support for all SQLocal methods including importing, exporting, and clearing the database.