### PR TITLE
add sah support

### DIFF
--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -64,6 +64,7 @@ export const db = new SQLocal({
 	databasePath: 'database.sqlite3',
 	readOnly: true,
 	verbose: true,
+	enableSyncAccessHandlePool: true,
 	onInit: (sql) => {},
 	onConnect: (reason) => {},
 });
@@ -72,6 +73,7 @@ export const db = new SQLocal({
 - **`databasePath`** (`string`) - The file name for the database file. This is the only required option.
 - **`readOnly`** (`boolean`) - If `true`, connect to the database in read-only mode. Attempts to run queries that would mutate the database will throw an error.
 - **`verbose`** (`boolean`) - If `true`, any SQL executed on the database will be logged to the console.
+- **`enableSyncAccessHandlePool`** (`boolean`) - If `true`, the [Sync Access Handle Pool](https://sqlite.org/wasm/doc/trunk/persistence.md#vfs-opfs-sahpool) will be enabled for the database. This provides better performance, but restricts access to the database file to one browser tab at a time. This also allows the database to function without the need for cross-origin isolation headers.
 - **`onInit`** (`function`) - A callback that will be run once when the client has initialized but before it has connected to the database. This callback should return an array of SQL statements (using the passed `sql` tagged template function, similar to the [`batch` method](../api/batch.md)) that should be executed before any other statements on the database connection. The `onInit` callback will be called only once, but the statements will be executed every time the client creates a new database connection. This makes it the best way to set up any `PRAGMA` settings, temporary tables, views, or triggers for the connection.
 - **`onConnect`** (`function`) - A callback that will be run after the client has connected to the database. This will happen at initialization and any time [`overwriteDatabaseFile`](/api/overwritedatabasefile) or [`deleteDatabaseFile`](/api/deletedatabasefile) is called on any SQLocal client connected to the same database. The callback is passed a string (`'initial' | 'overwrite' | 'delete'`) that indicates why the callback was executed. This callback is useful for syncing your application's state with data from the newly-connected database.
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -491,8 +491,4 @@ export class SQLocalProcessor {
 			});
 		}
 	};
-
-	getVfsList = () => {
-		return this.sqlite3?.capi.sqlite3_vfs_find(null);
-	};
 }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -66,6 +66,9 @@ export class SQLocalProcessor {
 		try {
 			if (!this.sqlite3) {
 				this.sqlite3 = await sqlite3InitModule();
+				if (this.config.enableSyncAccessHandlePool) {
+					await this.sqlite3.installOpfsSAHPoolVfs({});
+				}
 			}
 
 			if (this.db) {
@@ -487,5 +490,9 @@ export class SQLocalProcessor {
 				queryKey: message.queryKey,
 			});
 		}
+	};
+
+	getVfsList = () => {
+		return this.sqlite3?.capi.sqlite3_vfs_find(null);
 	};
 }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -67,7 +67,9 @@ export class SQLocalProcessor {
 			if (!this.sqlite3) {
 				this.sqlite3 = await sqlite3InitModule();
 				if (this.config.enableSyncAccessHandlePool) {
-					await this.sqlite3.installOpfsSAHPoolVfs({});
+					await this.sqlite3.installOpfsSAHPoolVfs({
+						directory: this.config.databasePath,
+					});
 				}
 			}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export type ClientConfig = {
 	verbose?: boolean;
 	onInit?: (sql: typeof sqlTag) => void | Statement[];
 	onConnect?: (reason: ConnectReason) => void;
+	enableSyncAccessHandlePool?: boolean;
 };
 
 export type ProcessorConfig = {
@@ -65,6 +66,7 @@ export type ProcessorConfig = {
 	verbose?: boolean;
 	clientKey?: QueryKey;
 	onInitStatements?: Statement[];
+	enableSyncAccessHandlePool?: boolean;
 };
 
 export type DatabaseInfo = {


### PR DESCRIPTION
As discussed in https://github.com/DallasHoff/sqlocal/issues/39, a lot more effort needs to be put in to fully support the Sync Access Handle Pool method of persistent storage, but having the configuration option could still be valuable if the end user is willing to implement the leader tab/locking mechanism themselves.

This is the case for my use case, where I currently need to do a yarn patch of the library to use it for my purposes.