### PR TITLE
Use Prepared Statements for Batch Queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"test:ui": "vitest --ui --browser=chrome",
 		"test:ci": "vitest run --browser=chrome",
 		"test:safari": "vitest --browser=safari --browser.headless=false",
+		"benchmark": "vitest bench --browser=chrome",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",
 		"docs:dev": "vitepress dev docs",

--- a/src/drivers/sqlite-memory-driver.ts
+++ b/src/drivers/sqlite-memory-driver.ts
@@ -10,6 +10,7 @@ import type {
 	UserFunction,
 } from '../types.js';
 import { normalizeDatabaseFile } from '../lib/normalize-database-file.js';
+import type { PreparedStatement } from '@sqlite.org/sqlite-wasm';
 
 export class SQLiteMemoryDriver implements SQLocalDriver {
 	protected sqlite3?: Sqlite3;
@@ -56,9 +57,37 @@ export class SQLiteMemoryDriver implements SQLocalDriver {
 		const results: RawResultData[] = [];
 
 		this.db.transaction((tx) => {
-			for (let statement of statements) {
-				const statementData = this.execOnDb(tx, statement);
-				results.push(statementData);
+			const prepared = new Map<string, PreparedStatement>();
+
+			try {
+				for (let statement of statements) {
+					let stmt = prepared.get(statement.sql);
+
+					if (!stmt) {
+						const newStmt = tx.prepare(statement.sql);
+						prepared.set(statement.sql, newStmt);
+						stmt = newStmt;
+					}
+
+					if (statement.params?.length) {
+						stmt.bind(statement.params);
+					}
+
+					let columns: string[] = [];
+					let rows: unknown[][] = [];
+
+					while (stmt.step()) {
+						columns = stmt.getColumnNames([]);
+						rows.push(stmt.get([]));
+					}
+
+					results.push({ columns, rows });
+					stmt.reset();
+				}
+			} finally {
+				prepared.forEach((stmt) => {
+					stmt.finalize();
+				});
 			}
 		});
 

--- a/test/benchmarks/batch.bench.ts
+++ b/test/benchmarks/batch.bench.ts
@@ -14,8 +14,8 @@ describe.each([
 
 	bench('batch large replace', async () => {
 		await batch((sql) => {
-			return new Array(50000).fill(null).map((_, i) => {
-				const id = (i % 5000) + 1;
+			return new Array(5000).fill(null).map((_, i) => {
+				const id = (i % 500) + 1;
 				return sql`INSERT OR REPLACE INTO groceries (id, name, num) VALUES (${id}, ${'item' + id}, ${(i % 15) + 1})`;
 			});
 		});

--- a/test/benchmarks/batch.bench.ts
+++ b/test/benchmarks/batch.bench.ts
@@ -1,0 +1,23 @@
+import { bench, describe } from 'vitest';
+import { SQLocal } from '../../src/client.js';
+
+describe.each([
+	{ type: 'opfs', path: 'batch-bench.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
+	{ type: 'local', path: ':localStorage:' },
+	{ type: 'session', path: ':sessionStorage:' },
+])('batch ($type)', async ({ path }) => {
+	const { sql, batch } = new SQLocal(path);
+
+	await sql`DROP TABLE IF EXISTS groceries`;
+	await sql`CREATE TABLE groceries (id INTEGER PRIMARY KEY, name TEXT NOT NULL, num INTEGER NOT NULL)`;
+
+	bench('batch large replace', async () => {
+		await batch((sql) => {
+			return new Array(50000).fill(null).map((_, i) => {
+				const id = (i % 5000) + 1;
+				return sql`INSERT OR REPLACE INTO groceries (id, name, num) VALUES (${id}, ${'item' + id}, ${(i % 15) + 1})`;
+			});
+		});
+	});
+});


### PR DESCRIPTION
Changes the implementation used by the [`batch`](https://sqlocal.dev/api/batch) method and Drizzle's `batch` method to use prepared statements automatically. This speeds it up when the batch repeats the same statement multiple times, just with different bind parameters.