### PR TITLE
Reactive Queries

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -55,6 +55,10 @@ export default defineConfig({
 						link: '/api/transaction',
 					},
 					{
+						text: 'reactiveQuery',
+						link: '/api/reactivequery',
+					},
+					{
 						text: 'getDatabaseInfo',
 						link: '/api/getdatabaseinfo',
 					},

--- a/docs/api/reactivequery.md
+++ b/docs/api/reactivequery.md
@@ -1,3 +1,87 @@
 # reactiveQuery
 
-TODO
+Subscribe to a SQL query and receive the latest results whenever the read tables change.
+
+## Usage
+
+Access or destructure `reactiveQuery` from the `SQLocal` client. To enable this feature, the `reactive` option must be set to `true`.
+
+```javascript
+import { SQLocal } from 'sqlocal';
+
+const { reactiveQuery } = new SQLocal({
+	databasePath: 'database.sqlite3',
+	reactive: true,
+});
+```
+
+<!-- @include: ../.partials/initialization-note.md -->
+
+The `reactiveQuery` method takes a SQL query and allows you to subscribe to its results. When you call the `subscribe` method it returns, the query will run and its result data will be passed to your callback, and any time the database tables that are read from in that query get updated, the query will automatically re-run and pass the latest results to the callback.
+
+The query can automatically react to mutations made on the database by the same _or_ other `SQLocal` instances that have the `reactive` option set to `true`, even if they are done in other windows/tabs of the web app. Inserts, updates, or deletes to the relevent database tables from any scope will trigger the subscription.
+
+```javascript
+const subscription = reactiveQuery(
+	(sql) => sql`SELECT name FROM groceries`
+).subscribe((data) => {
+	console.log('Grocery List Updated:', data);
+});
+```
+
+The query can be any SQL statement that reads one or more tables. It can be passed using a `sql` tag function available in the `reactiveQuery` callback that works similarly to the [`sql` tag function used for single queries](sql.md). It can also be a query built with Drizzle or Kysely; see the "Query Builders" section below.
+
+You can then call `subscribe` on the object returned from `reactiveQuery` to register a callback that gets called an initial time and then again whenever the one or more of the queried tables are changed. The latest result data from the query will be passed as the first argument to your callback.
+
+You can also pass a second callback to `subscribe` that will be called if there are any errors when running your query.
+
+```javascript
+const groceries = reactiveQuery((sql) => sql`SELECT name FROM groceries`);
+
+const subscription = groceries.subscribe(
+	(data) => {
+		console.log('Grocery List Updated:', data);
+	},
+	(err) => {
+		console.error('Query Error:', err);
+	}
+);
+```
+
+To stop receiving updates and clean up the subscription, call `unsubscribe` on the object returned from `subscribe`.
+
+```javascript
+subscription.unsubscribe();
+```
+
+Note that mutations that happen inside a [transaction](transaction.md) will not trigger reactive queries until the transaction is committed. This ensures your data does not get out of sync in the case that the transaction is rolled back. Also, because of [SQLite's "Truncate Optimization"](https://sqlite.org/lang_delete.html#truncateopt), reactive queries will not be triggered by DELETE statements that have no WHERE clause, RETURNING clause, or table triggers.
+
+## Query Builders
+
+If you are using a query builder, you can use it to create the reactive query, rather than use the `sql` tag function. The data emitted in the `subscribe` callback will then be fully typed by the query builder.
+
+### Drizzle
+
+With Drizzle ORM, construct a query and pass it to `reactiveQuery` without executing it.
+
+```javascript
+const subscription = reactiveQuery(
+	db.select({ name: groceries.name }).from(groceries)
+).subscribe((data) => {
+	// data is typed as { name: string; }[]
+	console.log('Grocery List Updated:', data);
+});
+```
+
+### Kysely
+
+With Kysely, construct a query, call the `compile` method on it, and pass it to `reactiveQuery`.
+
+```javascript
+const subscription = reactiveQuery(
+	db.selectFrom('groceries').select('name').compile()
+).subscribe((data) => {
+	// data is typed as { name: string; }[]
+	console.log('Grocery List Updated:', data);
+});
+```

--- a/docs/api/reactivequery.md
+++ b/docs/api/reactivequery.md
@@ -1,0 +1,3 @@
+# reactiveQuery
+
+TODO

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,9 +76,9 @@ export class SQLocal {
 		);
 
 		if (commonConfig.reactive) {
-			this.effectsChannel = new BroadcastChannel(
-				`_sqlocal_effects_(${databasePath})`
-			);
+			const dbKey =
+				databasePath === ':memory:' ? `memory:${this.clientKey}` : databasePath;
+			this.effectsChannel = new BroadcastChannel(`_sqlocal_effects_(${dbKey})`);
 		}
 
 		if (typeof processor !== 'undefined') {

--- a/src/client.ts
+++ b/src/client.ts
@@ -387,6 +387,7 @@ export class SQLocal {
 		passStatement: StatementInput<Result>
 	): ReactiveQuery<Result> => {
 		let value: Result[] = [];
+		let gotFirstValue = false;
 		let isListening = false;
 		let updateCount = 0;
 
@@ -436,6 +437,7 @@ export class SQLocal {
 
 				if (updateOrder === updateCount) {
 					value = results;
+					gotFirstValue = true;
 					subObservers.forEach((observer) => observer(value));
 				}
 			} catch (err) {
@@ -478,7 +480,7 @@ export class SQLocal {
 					this.effectsChannel.addEventListener('message', onEffect);
 					isListening = true;
 					runStatement();
-				} else {
+				} else if (gotFirstValue) {
 					onData(value);
 				}
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -41,6 +41,7 @@ import { mutationLock } from './lib/mutation-lock.js';
 import { normalizeDatabaseFile } from './lib/normalize-database-file.js';
 import { SQLiteMemoryDriver } from './drivers/sqlite-memory-driver.js';
 import { SQLiteKvvfsDriver } from './drivers/sqlite-kvvfs-driver.js';
+import { getDatabaseKey } from './lib/get-database-key.js';
 
 export class SQLocal {
 	protected config: ClientConfig;
@@ -71,13 +72,11 @@ export class SQLocal {
 
 		this.config = clientConfig;
 		this.clientKey = getQueryKey();
-		this.reinitChannel = new BroadcastChannel(
-			`_sqlocal_reinit_(${databasePath})`
-		);
+		const dbKey = getDatabaseKey(databasePath, this.clientKey);
+
+		this.reinitChannel = new BroadcastChannel(`_sqlocal_reinit_(${dbKey})`);
 
 		if (commonConfig.reactive) {
-			const dbKey =
-				databasePath === ':memory:' ? `memory:${this.clientKey}` : databasePath;
 			this.effectsChannel = new BroadcastChannel(`_sqlocal_effects_(${dbKey})`);
 		}
 

--- a/src/drivers/sqlite-kvvfs-driver.ts
+++ b/src/drivers/sqlite-kvvfs-driver.ts
@@ -48,6 +48,7 @@ export class SQLiteKvvfsDriver
 			flags,
 		});
 		this.config = config;
+		this.initWriteHook();
 	}
 
 	override async isDatabasePersisted(): Promise<boolean> {
@@ -81,5 +82,6 @@ export class SQLiteKvvfsDriver
 
 	override async destroy(): Promise<void> {
 		this.closeDb();
+		this.writeCallbacks.clear();
 	}
 }

--- a/src/drivers/sqlite-memory-driver.ts
+++ b/src/drivers/sqlite-memory-driver.ts
@@ -44,6 +44,7 @@ export class SQLiteMemoryDriver implements SQLocalDriver {
 
 		this.db = new this.sqlite3.oo1.DB(databasePath, flags);
 		this.config = config;
+		this.initWriteHook();
 	}
 
 	onWrite(callback: (change: DataChange) => void): () => void {

--- a/src/drivers/sqlite-opfs-driver.ts
+++ b/src/drivers/sqlite-opfs-driver.ts
@@ -42,6 +42,7 @@ export class SQLiteOpfsDriver
 
 		this.db = new this.sqlite3.oo1.OpfsDb(databasePath, flags);
 		this.config = config;
+		this.initWriteHook();
 	}
 
 	override async isDatabasePersisted(): Promise<boolean> {
@@ -112,5 +113,6 @@ export class SQLiteOpfsDriver
 
 	override async destroy(): Promise<void> {
 		this.closeDb();
+		this.writeCallbacks.clear();
 	}
 }

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,0 +1,151 @@
+/**
+ * Lodash (Custom Build) <https://lodash.com/>
+ * Build: `lodash modularize exports="es" include="debounce" -p -o ./`
+ * Copyright JS Foundation and other contributors <https://js.foundation/>
+ * Released under MIT license <https://lodash.com/license>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ */
+
+export type DebounceOptions = {
+	leading?: boolean;
+	maxWait?: number;
+	trailing?: boolean;
+};
+
+export type DebouncedFunction<T extends (...args: any[]) => any> = {
+	(...args: Parameters<T>): ReturnType<T> | undefined;
+	cancel: () => void;
+	flush: () => ReturnType<T> | undefined;
+};
+
+export function debounce<T extends (...args: any[]) => any>(
+	func: T,
+	wait: number,
+	options?: DebounceOptions
+): DebouncedFunction<T> {
+	let lastArgs: Parameters<T> | undefined;
+	let lastThis: any;
+	let maxWait: number;
+	let result: ReturnType<T> | undefined;
+	let timerId: ReturnType<typeof setTimeout> | undefined;
+	let lastCallTime: number | undefined;
+	let lastInvokeTime = 0;
+
+	let leading = false;
+	let maxing = false;
+	let trailing = true;
+
+	if (typeof func !== 'function') {
+		throw new TypeError('Expected a function');
+	}
+
+	wait = Number(wait) || 0;
+
+	if (typeof options === 'object' && options !== null) {
+		leading = !!options.leading;
+		maxing = 'maxWait' in options;
+		maxWait = maxing ? Math.max(Number(options.maxWait) || 0, wait) : 0;
+		trailing = 'trailing' in options ? !!options.trailing : trailing;
+	}
+
+	function invokeFunc(time: number): ReturnType<T> | undefined {
+		const args = lastArgs!;
+		const thisArg = lastThis;
+
+		lastArgs = lastThis = undefined;
+		lastInvokeTime = time;
+		result = func.apply(thisArg, args);
+		return result;
+	}
+
+	function leadingEdge(time: number): ReturnType<T> | undefined {
+		lastInvokeTime = time;
+		timerId = setTimeout(timerExpired, wait);
+		return leading ? invokeFunc(time) : result;
+	}
+
+	function remainingWait(time: number): number {
+		const timeSinceLastCall = time - (lastCallTime ?? 0);
+		const timeSinceLastInvoke = time - lastInvokeTime;
+		const timeWaiting = wait - timeSinceLastCall;
+
+		return maxing
+			? Math.min(timeWaiting, maxWait - timeSinceLastInvoke)
+			: timeWaiting;
+	}
+
+	function shouldInvoke(time: number): boolean {
+		const timeSinceLastCall = time - (lastCallTime ?? 0);
+		const timeSinceLastInvoke = time - lastInvokeTime;
+
+		return (
+			lastCallTime === undefined ||
+			timeSinceLastCall >= wait ||
+			timeSinceLastCall < 0 ||
+			(maxing && timeSinceLastInvoke >= maxWait)
+		);
+	}
+
+	function timerExpired() {
+		const time = Date.now();
+		if (shouldInvoke(time)) {
+			return trailingEdge(time);
+		}
+		timerId = setTimeout(timerExpired, remainingWait(time));
+	}
+
+	function trailingEdge(time: number): ReturnType<T> | undefined {
+		timerId = undefined;
+
+		if (trailing && lastArgs) {
+			return invokeFunc(time);
+		}
+		lastArgs = lastThis = undefined;
+		return result;
+	}
+
+	function cancel() {
+		if (timerId !== undefined) {
+			clearTimeout(timerId);
+		}
+		lastInvokeTime = 0;
+		lastArgs = lastCallTime = lastThis = timerId = undefined;
+	}
+
+	function flush(): ReturnType<T> | undefined {
+		return timerId === undefined ? result : trailingEdge(Date.now());
+	}
+
+	function debounced() {
+		const time = Date.now();
+		const isInvoking = shouldInvoke(time);
+
+		// @ts-ignore
+		lastArgs = arguments;
+		// @ts-ignore
+		lastThis = this;
+		lastCallTime = time;
+
+		if (isInvoking) {
+			if (timerId === undefined) {
+				return leadingEdge(lastCallTime);
+			}
+			if (maxing) {
+				timerId = setTimeout(timerExpired, wait);
+				return invokeFunc(lastCallTime);
+			}
+		}
+
+		if (timerId === undefined) {
+			timerId = setTimeout(timerExpired, wait);
+		}
+
+		return result;
+	}
+
+	debounced.cancel = cancel;
+	debounced.flush = flush;
+
+	return debounced;
+}

--- a/src/lib/get-database-key.ts
+++ b/src/lib/get-database-key.ts
@@ -1,0 +1,31 @@
+import type { DatabasePath } from '../types.js';
+import { getQueryKey } from './get-query-key.js';
+
+export function getDatabaseKey(databasePath: DatabasePath, clientKey: string) {
+	switch (databasePath) {
+		case 'session':
+		case ':sessionStorage:':
+			// The sessionStorage DB can be shared between clients in the same tab
+			let sessionKey = sessionStorage._sqlocal_session_key;
+
+			if (!sessionKey) {
+				sessionKey = getQueryKey();
+				sessionStorage._sqlocal_session_key = sessionKey;
+			}
+
+			return `session:${sessionKey}`;
+
+		case 'local':
+		case ':localStorage:':
+			// There's only one localStorage DB per origin
+			return 'local';
+
+		case ':memory:':
+			// Each memory DB is unique to a client
+			return `memory:${clientKey}`;
+
+		default:
+			// OPFS DBs are shared by path across same-origin tabs
+			return `path:${databasePath}`;
+	}
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -141,3 +141,8 @@ export type CloseBroadcast = {
 	type: 'close';
 	clientKey: QueryKey;
 };
+
+export type EffectsMessage = {
+	type: 'effects';
+	tables: string[];
+};

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -98,7 +98,7 @@ export class SQLocalProcessor {
 				})
 			);
 
-			if (this.config.reactive && this.driver.storageType !== 'memory') {
+			if (this.config.reactive) {
 				this.effectsChannel = new BroadcastChannel(
 					`_sqlocal_effects_(${this.config.databasePath})`
 				);

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -98,7 +98,7 @@ export class SQLocalProcessor {
 				})
 			);
 
-			if (this.config.reactive) {
+			if (this.config.reactive && this.driver.storageType !== 'memory') {
 				this.effectsChannel = new BroadcastChannel(
 					`_sqlocal_effects_(${this.config.databasePath})`
 				);

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,13 @@ export type Transaction = {
 	rollback: () => Promise<void>;
 };
 
+export type ReactiveQuery<Result = unknown> = {
+	readonly value: Result[];
+	subscribe: (observer: (value: Result[]) => void) => {
+		unsubscribe: () => void;
+	};
+};
+
 export type RawResultData = {
 	rows: unknown[] | unknown[][];
 	columns: string[];
@@ -61,6 +68,7 @@ export interface SQLocalDriver {
 	init: (config: DriverConfig) => Promise<void>;
 	exec: (statement: DriverStatement) => Promise<RawResultData>;
 	execBatch: (statements: DriverStatement[]) => Promise<RawResultData[]>;
+	onWrite: (callback: (change: DataChange) => void) => () => void;
 	isDatabasePersisted: () => Promise<boolean>;
 	getDatabaseSizeBytes: () => Promise<number>;
 	createFunction: (fn: UserFunction) => Promise<void>;
@@ -74,6 +82,7 @@ export interface SQLocalDriver {
 
 export type DriverConfig = {
 	databasePath?: DatabasePath;
+	reactive?: boolean;
 	readOnly?: boolean;
 	verbose?: boolean;
 };
@@ -99,6 +108,7 @@ export type ConnectReason = 'initial' | 'overwrite' | 'delete';
 
 export type ClientConfig = {
 	databasePath: DatabasePath;
+	reactive?: boolean;
 	readOnly?: boolean;
 	verbose?: boolean;
 	onInit?: (sql: typeof sqlTag) => void | Statement[];
@@ -108,6 +118,7 @@ export type ClientConfig = {
 
 export type ProcessorConfig = {
 	databasePath?: DatabasePath;
+	reactive?: boolean;
 	readOnly?: boolean;
 	verbose?: boolean;
 	clientKey?: QueryKey;
@@ -119,6 +130,12 @@ export type DatabaseInfo = {
 	databaseSizeBytes?: number;
 	storageType?: Sqlite3StorageType;
 	persisted?: boolean;
+};
+
+export type DataChange = {
+	operation: 'insert' | 'update' | 'delete';
+	table: string;
+	rowid: BigInt;
 };
 
 // User functions

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,10 @@ export type Transaction = {
 
 export type ReactiveQuery<Result = unknown> = {
 	readonly value: Result[];
-	subscribe: (observer: (value: Result[]) => void) => {
+	subscribe: (
+		onData: (results: Result[]) => void,
+		onError?: (err: Error) => void
+	) => {
 		unsubscribe: () => void;
 	};
 };

--- a/test/get-database-file.test.ts
+++ b/test/get-database-file.test.ts
@@ -12,7 +12,7 @@ describe.each([
 
 	it(
 		'should return the requested database file',
-		{ timeout: ['local', 'session'].includes(type) ? 3000 : undefined },
+		{ timeout: ['local', 'session'].includes(type) ? 3000 : 1500 },
 		async () => {
 			for (let path of paths) {
 				const databasePath = [...path, fileName].join('/');

--- a/test/overwrite-database-file.test.ts
+++ b/test/overwrite-database-file.test.ts
@@ -162,6 +162,7 @@ describe.each([
 
 		const dbFile = await db.getDatabaseFile();
 		await db.overwriteDatabaseFile(dbFile);
+		await sleep(100);
 
 		const num2 = await db.sql`SELECT double(2) AS num`;
 		expect(num2).toEqual([{ num: 4 }]);

--- a/test/reactive-query.test.ts
+++ b/test/reactive-query.test.ts
@@ -8,6 +8,7 @@ import {
 	vi,
 } from 'vitest';
 import { SQLocal } from '../src/client.js';
+import { sleep } from './test-utils/sleep.js';
 
 describe.each([
 	{ type: 'opfs', path: 'reactive-query-test.sqlite3' },
@@ -19,10 +20,12 @@ describe.each([
 
 	beforeEach(async () => {
 		await db1.sql`CREATE TABLE groceries (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;
+		await db1.sql`CREATE TABLE todos (title TEXT NOT NULL)`;
 	});
 
 	afterEach(async () => {
 		await db1.sql`DROP TABLE groceries`;
+		await db1.sql`DROP TABLE todos`;
 	});
 
 	afterAll(async () => {
@@ -36,23 +39,32 @@ describe.each([
 		async () => {
 			let list1: string[] = [];
 			let list2: string[] = [];
+			let todosUpdated = false;
+
 			const reactive1 = db1.reactiveQuery(
 				(sql) => sql`SELECT * FROM groceries`
 			);
 			const reactive2 = db2.reactiveQuery(
 				(sql) => sql`SELECT * FROM groceries`
 			);
-			const { unsubscribe: unsubscribe1 } = reactive1.subscribe(
-				(data) => (list1 = data.map(({ name }) => name))
+			const reactiveExtra = db2.reactiveQuery(
+				(sql) => sql`SELECT * FROM todos`
 			);
-			const { unsubscribe: unsubscribe2 } = reactive2.subscribe(
-				(data) => (list2 = data.map(({ name }) => name))
+			const callback1 = vi.fn(
+				(data: Record<string, any>[]) => (list1 = data.map(({ name }) => name))
 			);
+			const callback2 = vi.fn(
+				(data: Record<string, any>[]) => (list2 = data.map(({ name }) => name))
+			);
+			const { unsubscribe: unsubscribe1 } = reactive1.subscribe(callback1);
+			const { unsubscribe: unsubscribe2 } = reactive2.subscribe(callback2);
+			reactiveExtra.subscribe(() => (todosUpdated = true));
 
 			let expected: string[] = [];
 			expect(list1).toEqual(expected);
 			expect(list2).toEqual(expected);
 
+			// Insert
 			await db1.sql`INSERT INTO groceries (name) VALUES ('bread'), ('eggs')`;
 			await vi.waitUntil(() => list1.length === 2 && list2.length === 2);
 
@@ -60,6 +72,7 @@ describe.each([
 			expect(list1).toEqual(expected);
 			expect(list2).toEqual(expected);
 
+			// Update
 			await db2.sql`UPDATE groceries SET name = 'wheat bread' WHERE name = 'bread'`;
 			await vi.waitUntil(
 				() => list1.includes('wheat bread') && list2.includes('wheat bread')
@@ -69,6 +82,7 @@ describe.each([
 			expect(list1).toEqual(expected);
 			expect(list2).toEqual(expected);
 
+			// Delete
 			await db1.sql`DELETE FROM groceries WHERE name = 'wheat bread'`;
 			await vi.waitUntil(() => list1.length === 1 && list2.length === 1);
 
@@ -76,9 +90,21 @@ describe.each([
 			expect(list1).toEqual(expected);
 			expect(list2).toEqual(expected);
 
+			// Edit unrelated table
+			todosUpdated = false;
+			const prevCallCount = callback1.mock.calls.length;
+			await db1.sql`INSERT INTO todos (title) VALUES ('laundry')`;
+			await vi.waitUntil(() => todosUpdated === true);
+			await sleep(100);
+
+			const newCallCount = callback1.mock.calls.length;
+			expect(newCallCount).toBe(prevCallCount);
+
+			// Unsubscribe
 			unsubscribe1();
 			await db1.sql`INSERT INTO groceries (name) VALUES ('rice')`;
 			await vi.waitUntil(() => list2.length === 2);
+			await sleep(100);
 
 			expect(list1).toEqual(['eggs']);
 			expect(list2).toEqual(['eggs', 'rice']);

--- a/test/reactive-query.test.ts
+++ b/test/reactive-query.test.ts
@@ -224,6 +224,9 @@ describe.each([
 			list2 = data.map(({ name }) => name);
 		});
 
+		// The value property should contain an empty array initially
+		expect(reactive.value).toEqual([]);
+
 		// Make 2 subscriptions
 		let { unsubscribe: unsubscribe1 } = reactive.subscribe(callback1);
 		let { unsubscribe: unsubscribe2 } = reactive.subscribe(callback2);
@@ -233,6 +236,7 @@ describe.each([
 		expect(callback2).toHaveBeenCalledTimes(1);
 		expect(list1).toEqual(expectedList);
 		expect(list2).toEqual(expectedList);
+		expect(reactive.value.map(({ name }) => name)).toEqual(expectedList);
 
 		// Inserting data should notify both subscribers
 		await db1.sql`INSERT INTO groceries (name) VALUES ('apples'), ('oranges')`;
@@ -243,6 +247,7 @@ describe.each([
 		expect(callback2).toHaveBeenCalledTimes(2);
 		expect(list1).toEqual(expectedList);
 		expect(list2).toEqual(expectedList);
+		expect(reactive.value.map(({ name }) => name)).toEqual(expectedList);
 
 		// Unsubscribe 1 and make sure only the other subscriber is notified again
 		unsubscribe1();
@@ -254,6 +259,7 @@ describe.each([
 		expect(callback2).toHaveBeenCalledTimes(3);
 		expect(list1).toEqual(['apples', 'oranges']);
 		expect(list2).toEqual(expectedList);
+		expect(reactive.value.map(({ name }) => name)).toEqual(expectedList);
 
 		// Resubscribe the second subscription
 		({ unsubscribe: unsubscribe1 } = reactive.subscribe(callback1));
@@ -263,6 +269,7 @@ describe.each([
 		expect(callback2).toHaveBeenCalledTimes(3);
 		expect(list1).toEqual(expectedList);
 		expect(list2).toEqual(expectedList);
+		expect(reactive.value.map(({ name }) => name)).toEqual(expectedList);
 
 		// Make another data change
 		await db1.sql`INSERT INTO groceries (name) VALUES ('grapes')`;
@@ -273,6 +280,7 @@ describe.each([
 		expect(callback2).toHaveBeenCalledTimes(4);
 		expect(list1).toEqual(expectedList);
 		expect(list2).toEqual(expectedList);
+		expect(reactive.value.map(({ name }) => name)).toEqual(expectedList);
 
 		// Unsubscribe
 		unsubscribe1();

--- a/test/reactive-query.test.ts
+++ b/test/reactive-query.test.ts
@@ -211,4 +211,13 @@ describe.each([
 			subscription2.unsubscribe();
 		}
 	);
+
+	it('should require the reactive setting to be true', async () => {
+		const db = new SQLocal({ databasePath: path });
+		const reactive = db.reactiveQuery((sql) => sql`SELECT * FROM foo`);
+
+		expect(() => reactive.subscribe(() => {})).toThrowError();
+
+		await db.destroy();
+	});
 });

--- a/test/reactive-query.test.ts
+++ b/test/reactive-query.test.ts
@@ -12,9 +12,10 @@ import { sleep } from './test-utils/sleep.js';
 
 describe.each([
 	{ type: 'opfs', path: 'reactive-query-test.sqlite3' },
+	{ type: 'memory', path: ':memory:' },
 	{ type: 'local', path: ':localStorage:' },
 	{ type: 'session', path: ':sessionStorage:' },
-])('reactiveQuery ($type)', async ({ path }) => {
+])('reactiveQuery ($type)', async ({ path, type }) => {
 	const db1 = new SQLocal({ databasePath: path, reactive: true });
 	const db2 = new SQLocal({ databasePath: path, reactive: true });
 
@@ -37,6 +38,9 @@ describe.each([
 		'should notify other instances of data changes',
 		{ timeout: 2000 },
 		async () => {
+			// Each in-memory database is fresh
+			if (type === 'memory') return;
+
 			let list1: string[] = [];
 			let list2: string[] = [];
 			let todosUpdated = false;
@@ -58,7 +62,9 @@ describe.each([
 			);
 			const { unsubscribe: unsubscribe1 } = reactive1.subscribe(callback1);
 			const { unsubscribe: unsubscribe2 } = reactive2.subscribe(callback2);
-			reactiveExtra.subscribe(() => (todosUpdated = true));
+			const { unsubscribe: unsubscribeExtra } = reactiveExtra.subscribe(
+				() => (todosUpdated = true)
+			);
 
 			let expected: string[] = [];
 			expect(list1).toEqual(expected);
@@ -109,7 +115,100 @@ describe.each([
 			expect(list1).toEqual(['eggs']);
 			expect(list2).toEqual(['eggs', 'rice']);
 
+			// Unsubscribing again is a no-op
+			unsubscribe1();
 			unsubscribe2();
+			unsubscribeExtra();
+		}
+	);
+
+	it(
+		'should notify reactive queries on the same instance',
+		{ timeout: 2000 },
+		async () => {
+			// This test will only involve db1
+			let list1: string[] = [];
+			let list2: string[] = [];
+			const reactive1 = db1.reactiveQuery((sql) => sql`SELECT * FROM todos`);
+			const reactive2 = db1.reactiveQuery(
+				(sql) => sql`SELECT * FROM todos WHERE title LIKE 'clean %'`
+			);
+			const callback1 = vi.fn((data: Record<string, any>[]) => {
+				list1 = data.map(({ title }) => title);
+			});
+			const callback2 = vi.fn((data: Record<string, any>[]) => {
+				list2 = data.map(({ title }) => title);
+			});
+			let subscription1, subscription2;
+
+			// Initial query result should be emitted on subscription
+			await db1.sql`INSERT INTO todos (title) VALUES ('vacuum')`;
+			await sleep(100);
+			subscription1 = reactive1.subscribe(callback1);
+			await vi.waitUntil(() => list1.length === 1);
+
+			expect(list1).toEqual(['vacuum']);
+			expect(callback1).toHaveBeenCalledOnce();
+
+			// Subscription should only emit once for multiple changes close together
+			await Promise.all([
+				db1.sql`INSERT INTO todos (title) VALUES ('clean bedroom')`,
+				db1.sql`INSERT INTO todos (title) VALUES ('dust')`,
+			]);
+			await vi.waitUntil(() => list1.length === 3);
+
+			expect(list1.sort()).toEqual(['vacuum', 'dust', 'clean bedroom'].sort());
+			expect(callback1).toHaveBeenCalledTimes(2);
+
+			// Delete with WHERE clause
+			await db1.sql`DELETE FROM todos WHERE title = 'dust'`;
+			await vi.waitUntil(() => list1.length === 2);
+
+			expect(list1).toEqual(['vacuum', 'clean bedroom']);
+			expect(callback1).toHaveBeenCalledTimes(3);
+
+			// Start a second subscription
+			subscription2 = reactive2.subscribe(callback2);
+			await vi.waitUntil(() => list2.length === 1);
+
+			expect(list1).toEqual(['vacuum', 'clean bedroom']);
+			expect(list2).toEqual(['clean bedroom']);
+			expect(callback1).toHaveBeenCalledTimes(3);
+			expect(callback2).toHaveBeenCalledTimes(1);
+
+			// Insert something for the second subscription
+			await db1.sql`INSERT INTO todos (title) VALUES ('clean kitchen')`;
+			await vi.waitUntil(() => list1.length === 3 && list2.length === 2);
+
+			expect(list1).toEqual(['vacuum', 'clean bedroom', 'clean kitchen']);
+			expect(list2).toEqual(['clean bedroom', 'clean kitchen']);
+			expect(callback1).toHaveBeenCalledTimes(4);
+			expect(callback2).toHaveBeenCalledTimes(2);
+
+			// Delete something the second subscription does not retrieve
+			await db1.sql`DELETE FROM todos WHERE title = 'vacuum'`;
+			await vi.waitUntil(() => list1.length === 2 && list2.length === 2);
+
+			const expectedList = ['clean bedroom', 'clean kitchen'];
+			expect(list1).toEqual(expectedList);
+			expect(list2).toEqual(expectedList);
+			expect(callback1).toHaveBeenCalledTimes(5);
+			expect(callback2).toHaveBeenCalledTimes(3);
+
+			// The SQLite "Truncate Optimization" will cause this statement to not emit an event
+			// https://sqlite.org/lang_delete.html#truncateopt
+			await db1.sql`DELETE FROM todos`;
+			await sleep(100);
+
+			expect(list1).toEqual(expectedList);
+			expect(list2).toEqual(expectedList);
+			expect(callback1).toHaveBeenCalledTimes(5);
+			expect(callback2).toHaveBeenCalledTimes(3);
+			await expect(db1.sql`SELECT * FROM todos`).resolves.toEqual([]);
+
+			// Unsubscribe
+			subscription1.unsubscribe();
+			subscription2.unsubscribe();
 		}
 	);
 });

--- a/test/reactive-query.test.ts
+++ b/test/reactive-query.test.ts
@@ -1,0 +1,76 @@
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+import { SQLocal } from '../src/client.js';
+
+describe.each([
+	{ type: 'opfs', path: 'reactive-query-test.sqlite3' },
+	{ type: 'local', path: ':localStorage:' },
+	{ type: 'session', path: ':sessionStorage:' },
+])('reactiveQuery ($type)', async ({ path }) => {
+	const db1 = new SQLocal({ databasePath: path, reactive: true });
+	const db2 = new SQLocal({ databasePath: path, reactive: true });
+
+	beforeEach(async () => {
+		await db1.sql`CREATE TABLE groceries (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;
+	});
+
+	afterEach(async () => {
+		await db1.sql`DROP TABLE groceries`;
+	});
+
+	afterAll(async () => {
+		await db1.destroy();
+		await db2.destroy();
+	});
+
+	it(
+		'should notify other instances of data changes',
+		{ timeout: 2000 },
+		async () => {
+			let list1: string[] = [];
+			let list2: string[] = [];
+			const reactive1 = db1.reactiveQuery(
+				(sql) => sql`SELECT * FROM groceries`
+			);
+			const reactive2 = db2.reactiveQuery(
+				(sql) => sql`SELECT * FROM groceries`
+			);
+			reactive1.subscribe((data) => (list1 = data.map(({ name }) => name)));
+			reactive2.subscribe((data) => (list2 = data.map(({ name }) => name)));
+
+			let expected: string[] = [];
+			expect(list1).toEqual(expected);
+			expect(list2).toEqual(expected);
+
+			await db1.sql`INSERT INTO groceries (name) VALUES ('bread'), ('eggs')`;
+			await vi.waitUntil(() => list1.length === 2 && list2.length === 2);
+
+			expected = ['bread', 'eggs'];
+			expect(list1).toEqual(expected);
+			expect(list2).toEqual(expected);
+
+			await db2.sql`UPDATE groceries SET name = 'wheat bread' WHERE name = 'bread'`;
+			await vi.waitUntil(
+				() => list1.includes('wheat bread') && list2.includes('wheat bread')
+			);
+
+			expected = ['wheat bread', 'eggs'];
+			expect(list1).toEqual(expected);
+			expect(list2).toEqual(expected);
+
+			await db1.sql`DELETE FROM groceries WHERE name = 'wheat bread'`;
+			await vi.waitUntil(() => list1.length === 1 && list2.length === 1);
+
+			expected = ['eggs'];
+			expect(list1).toEqual(expected);
+			expect(list2).toEqual(expected);
+		}
+	);
+});


### PR DESCRIPTION
Adds reactive queries: SQL queries where the result data can be subscribed to. When the data in the database tables that the query reads changes, the query automatically re-runs and emits the new results.

```typescript
const db = new SQLocal('db.sqlite3');

const subscription = db
  .reactiveQuery((sql) => sql`SELECT name FROM groceries`)
  .subscribe((data) => {
    const groceryList = data.map((item) => item.name).join(', ');
    console.log(`Grocery List: ${groceryList}`);
  });
```