### PR TITLE
Add `sqlite3InitModule` argument to `SQLiteOpfsDriver` constructor

### DIFF
--- a/src/drivers/sqlite-opfs-driver.ts
+++ b/src/drivers/sqlite-opfs-driver.ts
@@ -1,5 +1,6 @@
 import type {
 	DriverConfig,
+	Sqlite3InitModule,
 	Sqlite3StorageType,
 	SQLocalDriver,
 } from '../types.js';
@@ -12,6 +13,10 @@ export class SQLiteOpfsDriver
 	implements SQLocalDriver
 {
 	override readonly storageType: Sqlite3StorageType = 'opfs';
+
+	constructor(sqlite3InitModule?: Sqlite3InitModule) {
+		super(sqlite3InitModule);
+	}
 
 	override async init(config: DriverConfig): Promise<void> {
 		const { databasePath } = config;


### PR DESCRIPTION
I've also implemented the ability to pass `sqlite3InitModule` as an argument in `SQLiteOpfsDriver`. This creates parity between the different drivers, as this is also available in the `SQLiteMemoryDriver` and `SQLiteKvvfsDriver`.