### PR TITLE
feat: return numAffectedRows in Kysely driver

### DIFF
--- a/src/drivers/sqlite-memory-driver.ts
+++ b/src/drivers/sqlite-memory-driver.ts
@@ -203,6 +203,7 @@ export class SQLiteMemoryDriver implements SQLocalDriver {
 	}
 
 	protected execOnDb(db: Sqlite3Db, statement: DriverStatement): RawResultData {
+		const changesBefore = db.changes(true, true);
 		const statementData: RawResultData = {
 			rows: [],
 			columns: [],
@@ -228,6 +229,8 @@ export class SQLiteMemoryDriver implements SQLocalDriver {
 				break;
 		}
 
+		// @ts-expect-error https://github.com/sqlite/sqlite-wasm/pull/122
+		statementData.numAffectedRows = db.changes(true, true) - changesBefore;
 		return statementData;
 	}
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -108,6 +108,7 @@ export type DataMessage = {
 	data: {
 		columns: string[];
 		rows: unknown[] | unknown[][];
+		numAffectedRows?: bigint;
 	}[];
 };
 export type BufferMessage = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,8 @@ export type Transaction = {
 	) => Promise<Result[]>;
 	commit: () => Promise<void>;
 	rollback: () => Promise<void>;
+	lastAffectedRows?: bigint;
+	transactionKey: QueryKey;
 };
 
 export type ReactiveQuery<Result = unknown> = {
@@ -68,6 +70,7 @@ export type ReactiveQueryStatus = 'pending' | 'ok' | 'error';
 export type RawResultData = {
 	rows: unknown[] | unknown[][];
 	columns: string[];
+	numAffectedRows?: bigint;
 };
 
 // Driver


### PR DESCRIPTION
Hi, thanks for the great project! 

I moved a part of my project from better-sqlite3/Kysely to SQLocal/Kysely since I find it more convenient to work with a WASM blob rather than having to build a binary. In the process I noticed that I was no longer getting the `numAffectedRows` from Kysely's `executeQuery` call. This PR implement that.

To do this, I had to expose `execSql` method on the SQLocal/client class. Please let me know if this is not the way. It also adds a `lastAffectedRows` field to the transaction field. 

Tests were added as well.

Cheers