### PR TITLE
feat(client): allow overriding the worker URL

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -77,7 +77,8 @@ export class SQLocal {
 	constructor(config: DatabasePath | ClientConfig) {
 		const clientConfig =
 			typeof config === 'string' ? { databasePath: config } : config;
-		const { onInit, onConnect, processor, ...commonConfig } = clientConfig;
+		const { onInit, onConnect, processor, workerUrl, ...commonConfig } =
+			clientConfig;
 		const { databasePath } = commonConfig;
 
 		this.config = clientConfig;
@@ -105,9 +106,10 @@ export class SQLocal {
 			typeof globalThis.Worker !== 'undefined' &&
 			databasePath !== ':memory:'
 		) {
-			this.processor = new Worker(new URL('./worker', import.meta.url), {
-				type: 'module',
-			});
+			this.processor = new Worker(
+				workerUrl ?? new URL('./worker', import.meta.url),
+				{ type: 'module' },
+			);
 		} else {
 			const driver = new SQLiteMemoryDriver();
 			this.processor = new SQLocalProcessor(driver);

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,11 @@ export type ClientConfig = {
 	onInit?: (sql: SqlTag) => void | Statement[];
 	onConnect?: (reason: ConnectReason) => void;
 	processor?: SQLocalProcessor | Worker;
+	/**
+	 * Override the URL used to spawn the Web Worker.
+	 * @see {@link https://sqlocal.dev/guide/setup}
+	 */
+	workerUrl?: string | URL;
 };
 
 export type ProcessorConfig = {


### PR DESCRIPTION
Adds optional `workerUrl` to `ClientConfig`. Default unchanged; existing consumers unaffected.

```ts
new SQLocal({
  databasePath: 'app.sqlite3',
  workerUrl: '/sqlocal/worker.mjs',
});
```

Webpack injects an `importScripts()` chunk loader into the worker bundle (illegal in `type: 'module'` workers), and Next.js Turbopack rewrites the URL (issue #79). Both currently need a `patches/` override on `client.js` to point at a pre-bundled worker. This makes it a first-class option.