### PR TITLE
fix(processor): release transactionMutex when BEGIN/COMMIT/ROLLBACK throws

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -262,7 +262,13 @@ export class SQLocalProcessor {
 					if (message.action === 'begin') {
 						await this.transactionMutex.lock();
 						this.transactionKey = message.transactionKey;
-						await this.driver.exec({ sql: 'BEGIN' });
+						try {
+							await this.driver.exec({ sql: 'BEGIN' });
+						} catch (beginError) {
+							this.transactionKey = null;
+							await this.transactionMutex.unlock();
+							throw beginError;
+						}
 					}
 
 					if (
@@ -271,9 +277,12 @@ export class SQLocalProcessor {
 						this.transactionKey === message.transactionKey
 					) {
 						const sql = message.action === 'commit' ? 'COMMIT' : 'ROLLBACK';
-						await this.driver.exec({ sql });
-						this.transactionKey = null;
-						await this.transactionMutex.unlock();
+						try {
+							await this.driver.exec({ sql });
+						} finally {
+							this.transactionKey = null;
+							await this.transactionMutex.unlock();
+						}
 					}
 					break;
 			}

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -238,5 +238,23 @@ describe.each(testVariation('transaction'))(
 				['memory', 'opfs'].includes(type) ? [1, 2, 3] : [1, 3, 2]
 			);
 		});
+
+		it('should release the transaction mutex when a statement inside a transaction throws', async () => {
+			await expect(
+				db1.transaction(async (tx) => {
+					await tx.sql`SELECT * FROM table_that_does_not_exist`;
+				})
+			).rejects.toThrow();
+
+			const followUp = db1.sql`SELECT 1 AS ok`;
+			await expect(
+				Promise.race([
+					followUp,
+					sleep(1000).then(() => {
+						throw new Error('mutex leaked: follow-up query never resolved');
+					}),
+				])
+			).resolves.toEqual([{ ok: 1 }]);
+		});
 	}
 );


### PR DESCRIPTION
The `transaction` case of `SQLocalProcessor.exec` doesn't wrap its `driver.exec` calls in `try / finally`, so a `BEGIN` / `COMMIT` / `ROLLBACK` that throws leaks `transactionMutex` and every subsequent operation hangs on `transactionMutex.lock()`. The `query` and `batch` cases already do this correctly; this PR restores the symmetry.

Defensive: I could not reproduce the leak reliably from JS user space (body-throws path goes through `query` and a successful `ROLLBACK`), so the added test is a regression guard against future changes to the `transaction` case rather than a current reproducer.

Closes #105. Supersedes #103 (misdiagnosed as a race in `createMutex`).